### PR TITLE
Added protocol fee for inbound

### DIFF
--- a/contracts/svm-gateway/app/config-cli.ts
+++ b/contracts/svm-gateway/app/config-cli.ts
@@ -19,6 +19,7 @@ const PROGRAM_ID = new PublicKey("DJoFYDpgbTfxbXBv1QYhYGc9FK4J5FUKpYXAfSkHryXp")
 const CONFIG_SEED = "config";
 const TSS_SEED = "tsspda_v2";
 const VAULT_SEED = "vault";
+const FEE_VAULT_SEED = "fee_vault";
 const RATE_LIMIT_CONFIG_SEED = "rate_limit_config";
 const RATE_LIMIT_SEED = "rate_limit";
 
@@ -55,6 +56,11 @@ function deriveTssPda(): PublicKey {
 
 function deriveVaultPda(): PublicKey {
     const [pda] = PublicKey.findProgramAddressSync([Buffer.from(VAULT_SEED)], PROGRAM_ID);
+    return pda;
+}
+
+function deriveFeeVaultPda(): PublicKey {
+    const [pda] = PublicKey.findProgramAddressSync([Buffer.from(FEE_VAULT_SEED)], PROGRAM_ID);
     return pda;
 }
 
@@ -238,6 +244,45 @@ program_cli
             console.log(`   Transaction: ${tx}\n`);
         } catch (error: any) {
             console.error(`❌ Error unpausing gateway: ${error.message}`);
+            process.exit(1);
+        }
+    });
+
+// ============================================
+//             PROTOCOL FEE COMMANDS
+// ============================================
+
+program_cli
+    .command("fee:init")
+    .description("Initialize fee vault PDA (idempotent); optionally set initial protocol fee")
+    .option("--fee <lamports>", "Initial protocol fee in lamports (u64)", "0")
+    .action(async (options) => {
+        try {
+            console.log("=== INITIALIZING FEE VAULT ===\n");
+
+            const feeLamports = BigInt(options.fee);
+            const configPda = deriveConfigPda();
+            const feeVaultPda = deriveFeeVaultPda();
+
+            console.log(`Config PDA: ${configPda.toBase58()}`);
+            console.log(`Fee Vault PDA: ${feeVaultPda.toBase58()}`);
+            console.log(`Protocol Fee (lamports): ${feeLamports}\n`);
+
+            const tx = await program.methods
+                .setProtocolFee(new anchor.BN(feeLamports.toString()))
+                .accounts({
+                    config: configPda,
+                    feeVault: feeVaultPda,
+                    admin: adminKeypair.publicKey,
+                    systemProgram: SystemProgram.programId,
+                })
+                .signers([adminKeypair])
+                .rpc();
+
+            console.log(`✅ Fee vault initialized/updated successfully!`);
+            console.log(`   Transaction: ${tx}\n`);
+        } catch (error: any) {
+            console.error(`❌ Error initializing fee vault: ${error.message}`);
             process.exit(1);
         }
     });
@@ -468,7 +513,7 @@ program_cli
 
 program_cli
     .command("config:show")
-    .description("Show current gateway configuration (config + tss + rate_limit)")
+    .description("Show current gateway configuration (config + tss + rate_limit + fee_vault)")
     .action(async () => {
         try {
             console.log("=== GATEWAY CONFIGURATION ===\n");
@@ -476,6 +521,7 @@ program_cli
             const configPda = deriveConfigPda();
             const tssPda = deriveTssPda();
             const rateLimitConfigPda = deriveRateLimitConfigPda();
+            const feeVaultPda = deriveFeeVaultPda();
 
             // Fetch Config
             console.log("📋 Config Account");
@@ -505,6 +551,19 @@ program_cli
             try {
                 const rateLimitConfig = await (program.account as any).rateLimitConfig.fetch(rateLimitConfigPda);
                 formatAccount("Data", rateLimitConfig);
+            } catch (error: any) {
+                console.log(`   ❌ Not initialized: ${error.message}`);
+            }
+            console.log();
+
+            // Fetch Fee Vault
+            console.log("💸 Fee Vault");
+            console.log(`   PDA: ${feeVaultPda.toBase58()}`);
+            try {
+                const feeVault = await (program.account as any).feeVault.fetch(feeVaultPda);
+                formatAccount("Data", feeVault);
+                const feeVaultBalance = await connection.getBalance(feeVaultPda);
+                console.log(`   Balance (lamports): ${feeVaultBalance}`);
             } catch (error: any) {
                 console.log(`   ❌ Not initialized: ${error.message}`);
             }

--- a/contracts/svm-gateway/app/gateway-test.ts
+++ b/contracts/svm-gateway/app/gateway-test.ts
@@ -229,6 +229,10 @@ async function run() {
         [Buffer.from(VAULT_SEED)],
         PROGRAM_ID
     );
+    const [feeVaultPda] = PublicKey.findProgramAddressSync(
+        [Buffer.from("fee_vault")],
+        PROGRAM_ID
+    );
     const [tssPda] = PublicKey.findProgramAddressSync(
         [Buffer.from("tsspda_v2")],
         PROGRAM_ID
@@ -340,6 +344,7 @@ async function run() {
     console.log(`User: ${user.toString()}`);
     console.log(`Config PDA: ${configPda.toString()}`);
     console.log(`Vault PDA: ${vaultPda.toString()}\n`);
+    console.log(`Fee Vault PDA: ${feeVaultPda.toString()}\n`);
 
     // Step 1: Initialize Gateway
     console.log("1. Initializing Gateway...");
@@ -550,6 +555,7 @@ async function run() {
         .accounts({
             config: configPda,
             vault: vaultPda,
+            feeVault: feeVaultPda,
             userTokenAccount: vaultPda,
             gatewayTokenAccount: vaultPda,
             user: user,
@@ -587,6 +593,7 @@ async function run() {
         .accounts({
             config: configPda,
             vault: vaultPda,
+            feeVault: feeVaultPda,
             userTokenAccount: vaultPda,
             gatewayTokenAccount: vaultPda,
             user: user,
@@ -626,6 +633,7 @@ async function run() {
         .accounts({
             config: configPda,
             vault: vaultPda,
+            feeVault: feeVaultPda,
             userTokenAccount: vaultPda,
             gatewayTokenAccount: vaultPda,
             user: user,
@@ -670,6 +678,7 @@ async function run() {
             .accounts({
                 config: configPda,
                 vault: vaultPda,
+                feeVault: feeVaultPda,
                 userTokenAccount: tokenAccount,
                 gatewayTokenAccount: vaultAta.address,
                 user: user,
@@ -716,6 +725,7 @@ async function run() {
         .accounts({
             config: configPda,
             vault: vaultPda,
+            feeVault: feeVaultPda,
             userTokenAccount: vaultPda,
             gatewayTokenAccount: vaultPda,
             user: user,
@@ -781,6 +791,7 @@ async function run() {
             .accounts({
                 config: configPda,
                 vault: vaultPda,
+                feeVault: feeVaultPda,
                 userTokenAccount: tokenAccount,
                 gatewayTokenAccount: vaultAta.address,
                 user: user,
@@ -847,6 +858,7 @@ async function run() {
             .accounts({
                 config: configPda,
                 vault: vaultPda,
+                feeVault: feeVaultPda,
                 userTokenAccount: vaultPda,
                 gatewayTokenAccount: vaultPda,
                 user: user,
@@ -884,6 +896,7 @@ async function run() {
             .accounts({
                 config: configPda,
                 vault: vaultPda,
+                feeVault: feeVaultPda,
                 userTokenAccount: vaultPda,
                 gatewayTokenAccount: vaultPda,
                 user: user,
@@ -922,6 +935,7 @@ async function run() {
                 .accounts({
                     config: configPda,
                     vault: vaultPda,
+                    feeVault: feeVaultPda,
                     userTokenAccount: tokenAccount,
                     gatewayTokenAccount: vaultAta.address,
                     user: user,
@@ -958,6 +972,7 @@ async function run() {
             .accounts({
                 config: configPda,
                 vault: vaultPda,
+                feeVault: feeVaultPda,
                 userTokenAccount: vaultPda,
                 gatewayTokenAccount: vaultPda,
                 user: user,
@@ -995,6 +1010,7 @@ async function run() {
             .accounts({
                 config: configPda,
                 vault: vaultPda,
+                feeVault: feeVaultPda,
                 userTokenAccount: vaultPda,
                 gatewayTokenAccount: vaultPda,
                 user: user,
@@ -1030,6 +1046,7 @@ async function run() {
             .accounts({
                 config: configPda,
                 vault: vaultPda,
+                feeVault: feeVaultPda,
                 userTokenAccount: vaultPda,
                 gatewayTokenAccount: vaultPda,
                 user: user,
@@ -1069,6 +1086,7 @@ async function run() {
                 .accounts({
                     config: configPda,
                     vault: vaultPda,
+                    feeVault: feeVaultPda,
                     userTokenAccount: tokenAccount,
                     gatewayTokenAccount: tokenAccount, // ⚠️ ATTACK: User's own account instead of vault ATA
                     user: user,
@@ -1107,6 +1125,7 @@ async function run() {
                 .accounts({
                     config: configPda,
                     vault: vaultPda,
+                    feeVault: feeVaultPda,
                     userTokenAccount: tokenAccount,
                     gatewayTokenAccount: tokenAccount, // ⚠️ ATTACK: User's own account instead of vault ATA
                     user: user,
@@ -1156,6 +1175,7 @@ async function run() {
                 .accounts({
                     config: configPda,
                     vault: vaultPda,
+                    feeVault: feeVaultPda,
                     userTokenAccount: tokenAccount,
                     gatewayTokenAccount: wrongMintVaultAta, // ⚠️ ATTACK: Vault ATA but for wrong mint
                     user: user,
@@ -1220,6 +1240,7 @@ async function run() {
             .accounts({
                 config: configPda,
                 vault: vaultPda,
+                feeVault: feeVaultPda,
                 userTokenAccount: vaultPda,
                 gatewayTokenAccount: vaultPda,
                 user: user,
@@ -2962,6 +2983,7 @@ async function run() {
             .accounts({
                 config: configPda,
                 vault: vaultPda,
+                feeVault: feeVaultPda,
                 tssPda: tssPda,
                 recipient: admin,
                 executedSubTx: executedTxPdaRevert,

--- a/contracts/svm-gateway/app/simple-spl-test.ts
+++ b/contracts/svm-gateway/app/simple-spl-test.ts
@@ -17,6 +17,7 @@ import { Command } from "commander";
 const PROGRAM_ID = new PublicKey("CFVSincHYbETh2k7w6u1ENEkjbSLtveRCEBupKidw2VS");
 const CONFIG_SEED = "config";
 const VAULT_SEED = "vault";
+const FEE_VAULT_SEED = "fee_vault";
 const RATE_LIMIT_CONFIG_SEED = "rate_limit_config";
 const RATE_LIMIT_SEED = "rate_limit";
 
@@ -68,6 +69,10 @@ async function testDeposit(mintAddress: string, amount: number, tokenSymbol?: st
         [Buffer.from(VAULT_SEED)],
         PROGRAM_ID
     );
+    const [feeVaultPda] = PublicKey.findProgramAddressSync(
+        [Buffer.from(FEE_VAULT_SEED)],
+        PROGRAM_ID
+    );
     const [rateLimitConfigPda] = PublicKey.findProgramAddressSync(
         [Buffer.from(RATE_LIMIT_CONFIG_SEED)],
         PROGRAM_ID
@@ -102,6 +107,7 @@ async function testDeposit(mintAddress: string, amount: number, tokenSymbol?: st
     console.log(`Mint: ${mint.toString()}`);
     console.log(`Config PDA: ${configPda.toString()}`);
     console.log(`Vault PDA: ${vaultPda.toString()}`);
+    console.log(`Fee Vault PDA: ${feeVaultPda.toString()}`);
 
     // Step 1: Get vault ATA
     console.log("1. Getting vault ATA...");
@@ -175,8 +181,8 @@ async function testDeposit(mintAddress: string, amount: number, tokenSymbol?: st
                 .setTokenRateLimit(veryLargeThreshold)
                 .accounts({
                     config: configPda,
-                    rateLimitConfig: rateLimitConfigPda,
                     tokenRateLimit: splTokenRateLimitPda,
+                    tokenMint: mint,
                     admin: admin,
                     systemProgram: SystemProgram.programId,
                 })
@@ -193,6 +199,7 @@ async function testDeposit(mintAddress: string, amount: number, tokenSymbol?: st
         .accounts({
             config: configPda,
             vault: vaultPda,
+            feeVault: feeVaultPda,
             user: user,
             userTokenAccount: userTokenAccount.address,
             gatewayTokenAccount: vaultAta,

--- a/contracts/svm-gateway/package.json
+++ b/contracts/svm-gateway/package.json
@@ -15,6 +15,7 @@
     "config:tss-update": " ts-node app/config-cli.ts tss:update",
     "config:pause": " ts-node app/config-cli.ts pause",
     "config:unpause": " ts-node app/config-cli.ts unpause",
+    "config:fee-init": " ts-node app/config-cli.ts fee:init",
     "config:caps-set": " ts-node app/config-cli.ts caps:set",
     "config:pyth-set-feed": " ts-node app/config-cli.ts pyth:set-feed",
     "config:pyth-set-conf": " ts-node app/config-cli.ts pyth:set-conf",

--- a/contracts/svm-gateway/programs/universal-gateway/src/errors.rs
+++ b/contracts/svm-gateway/programs/universal-gateway/src/errors.rs
@@ -96,4 +96,10 @@ pub enum GatewayError {
 
     #[msg("Invalid instruction")]
     InvalidInstruction,
+
+    #[msg("Insufficient protocol fee")]
+    InsufficientProtocolFee,
+
+    #[msg("Fee vault has insufficient balance to reimburse relayer")]
+    InsufficientFeePool,
 }

--- a/contracts/svm-gateway/programs/universal-gateway/src/instructions/admin.rs
+++ b/contracts/svm-gateway/programs/universal-gateway/src/instructions/admin.rs
@@ -53,6 +53,39 @@ pub fn set_caps_usd(ctx: Context<AdminAction>, min_cap_usd: u128, max_cap_usd: u
     Ok(())
 }
 
+/// Admin action for fee vault operations (intentionally no `!config.paused` guard —
+/// the admin must be able to disable the fee even while paused).
+#[derive(Accounts)]
+pub struct FeeVaultAdminAction<'info> {
+    #[account(
+        seeds = [CONFIG_SEED],
+        bump = config.bump,
+        constraint = config.admin == admin.key() @ GatewayError::Unauthorized
+    )]
+    pub config: Account<'info, Config>,
+
+    #[account(
+        init_if_needed,
+        payer = admin,
+        space = FeeVault::LEN,
+        seeds = [FEE_VAULT_SEED],
+        bump,
+    )]
+    pub fee_vault: Account<'info, FeeVault>,
+
+    #[account(mut)]
+    pub admin: Signer<'info>,
+    pub system_program: Program<'info, System>,
+}
+
+pub fn set_protocol_fee(ctx: Context<FeeVaultAdminAction>, fee_lamports: u64) -> Result<()> {
+    // Keep bump persisted so seeded constraints continue to validate consistently.
+    ctx.accounts.fee_vault.bump = ctx.bumps.fee_vault;
+    ctx.accounts.fee_vault.protocol_fee_lamports = fee_lamports;
+    emit!(ProtocolFeeUpdated { new_fee_lamports: fee_lamports });
+    Ok(())
+}
+
 // Pyth oracle configuration functions
 pub fn set_pyth_price_feed(ctx: Context<AdminAction>, price_feed: Pubkey) -> Result<()> {
     require!(price_feed != Pubkey::default(), GatewayError::ZeroAddress);

--- a/contracts/svm-gateway/programs/universal-gateway/src/instructions/deposit.rs
+++ b/contracts/svm-gateway/programs/universal-gateway/src/instructions/deposit.rs
@@ -4,7 +4,7 @@ use crate::utils::*;
 use anchor_lang::prelude::*;
 use anchor_lang::solana_program::program_pack::Pack;
 use anchor_lang::system_program;
-use anchor_spl::token::{self, spl_token, Token, TokenAccount, Transfer};
+use anchor_spl::token::{self, spl_token, Token, Transfer};
 use pyth_solana_receiver_sdk::price_update::PriceUpdateV2;
 use spl_token::state::Account as SplAccount;
 // =========================
@@ -27,8 +27,44 @@ pub fn send_universal_tx(
         GatewayError::InsufficientBalance
     );
 
-    let tx_type = fetch_tx_type(&req, native_amount)?;
-    route_universal_tx(&mut ctx, req, native_amount, tx_type)
+    // Collect protocol fee first so all downstream routing sees post-fee native amount.
+    let adjusted_native_amount = collect_protocol_fee(&mut ctx, native_amount)?;
+
+    let tx_type = fetch_tx_type(&req, adjusted_native_amount)?;
+    route_universal_tx(&mut ctx, req, adjusted_native_amount, tx_type)
+}
+
+fn collect_protocol_fee(ctx: &mut Context<SendUniversalTx>, native_amount: u64) -> Result<u64> {
+    let fee_lamports = ctx.accounts.fee_vault.protocol_fee_lamports;
+    if fee_lamports == 0 {
+        return Ok(native_amount);
+    }
+
+    require!(
+        native_amount >= fee_lamports,
+        GatewayError::InsufficientProtocolFee
+    );
+
+    // Transfer fee from user → fee_vault (keeps bridge vault strictly 1:1 backed)
+    let cpi_ctx = CpiContext::new(
+        ctx.accounts.system_program.to_account_info(),
+        system_program::Transfer {
+            from: ctx.accounts.user.to_account_info(),
+            to: ctx.accounts.fee_vault.to_account_info(),
+        },
+    );
+    system_program::transfer(cpi_ctx, fee_lamports)?;
+
+    let adjusted_native_amount = native_amount - fee_lamports;
+
+    emit!(ProtocolFeeCollected {
+        payer: ctx.accounts.user.key(),
+        amount_lamports: fee_lamports,
+        native_amount_before: native_amount,
+        native_amount_after: adjusted_native_amount,
+    });
+
+    Ok(adjusted_native_amount)
 }
 
 /// @notice Internal router: dispatches to GAS or FUNDS handlers based on derived tx_type.
@@ -147,11 +183,6 @@ fn send_tx_with_gas_route(
 
         return Ok(());
     }
-
-    require!(
-        ctx.accounts.user.lamports() >= gas_amount,
-        GatewayError::InsufficientBalance
-    );
 
     // Performs rate-limit checks and handle deposit
     // USD caps: min $1, max $10 (enforced via Pyth oracle)
@@ -351,7 +382,6 @@ fn deposit_spl_to_vault(ctx: &Context<SendUniversalTx>, token: Pubkey, amount: u
 #[derive(Accounts)]
 pub struct SendUniversalTx<'info> {
     #[account(
-        mut,
         seeds = [CONFIG_SEED],
         bump = config.bump,
     )]
@@ -363,6 +393,15 @@ pub struct SendUniversalTx<'info> {
         bump = config.vault_bump,
     )]
     pub vault: SystemAccount<'info>,
+
+    /// Fee vault: receives the flat protocol fee per inbound tx.
+    /// Separate from bridge vault to preserve the 1:1 bridge invariant.
+    #[account(
+        mut,
+        seeds = [FEE_VAULT_SEED],
+        bump = fee_vault.bump,
+    )]
+    pub fee_vault: Account<'info, FeeVault>,
 
     /// CHECK: Only required for SPL token routes; validated at runtime.
     /// For native SOL routes, pass vault account as dummy (not used).

--- a/contracts/svm-gateway/programs/universal-gateway/src/instructions/revert.rs
+++ b/contracts/svm-gateway/programs/universal-gateway/src/instructions/revert.rs
@@ -1,6 +1,7 @@
 use crate::instructions::tss::validate_message;
 use crate::{errors::*, state::*};
 use anchor_lang::prelude::*;
+use anchor_lang::solana_program::sysvar::rent::Rent;
 use anchor_lang::solana_program::program_pack::Pack;
 use anchor_lang::solana_program::system_instruction;
 use anchor_spl::token::{self, spl_token, Mint, Token, TokenAccount, Transfer};
@@ -24,6 +25,14 @@ pub struct RevertUniversalTx<'info> {
     /// CHECK: SOL-only PDA, no data
     #[account(mut, seeds = [VAULT_SEED], bump = config.vault_bump)]
     pub vault: UncheckedAccount<'info>,
+
+    /// Fee vault — relayer gas reimbursement comes from here, not from bridge vault.
+    #[account(
+        mut,
+        seeds = [FEE_VAULT_SEED],
+        bump = fee_vault.bump,
+    )]
+    pub fee_vault: Account<'info, FeeVault>,
 
     #[account(
         mut,
@@ -118,14 +127,25 @@ pub fn revert_universal_tx(
         revert_instruction: revert_instruction.clone(),
     });
 
-    // Transfer gas fee to caller (relayer reimbursement)
-    crate::utils::transfer_gas_fee_to_caller(
-        &ctx.accounts.vault.to_account_info(),
-        &ctx.accounts.caller.to_account_info(),
-        &ctx.accounts.system_program.to_account_info(),
-        gas_fee,
-        ctx.accounts.config.vault_bump,
-    )?;
+    // Reimburse relayer gas from fee_vault (not from bridge vault — preserves 1:1 invariant).
+    if gas_fee > 0 {
+        let fee_vault_info = ctx.accounts.fee_vault.to_account_info();
+        let min_balance = Rent::get()?.minimum_balance(FeeVault::LEN);
+        let available = fee_vault_info
+            .lamports()
+            .checked_sub(min_balance)
+            .ok_or(error!(GatewayError::InsufficientFeePool))?;
+        require!(available >= gas_fee, GatewayError::InsufficientFeePool);
+
+        **fee_vault_info.try_borrow_mut_lamports()? -= gas_fee;
+        **ctx.accounts.caller.to_account_info().try_borrow_mut_lamports()? += gas_fee;
+
+        emit!(ProtocolFeeReimbursed {
+            sub_tx_id,
+            relayer: ctx.accounts.caller.key(),
+            amount_lamports: gas_fee,
+        });
+    }
 
     Ok(())
 }
@@ -148,6 +168,14 @@ pub struct RevertUniversalTxToken<'info> {
     /// CHECK: Vault token account - validated at runtime (owner == vault, mint == token_mint)
     #[account(mut)]
     pub token_vault: UncheckedAccount<'info>,
+
+    /// Fee vault — relayer gas reimbursement comes from here, not from bridge vault.
+    #[account(
+        mut,
+        seeds = [FEE_VAULT_SEED],
+        bump = fee_vault.bump,
+    )]
+    pub fee_vault: Account<'info, FeeVault>,
 
     #[account(
         mut,
@@ -175,14 +203,6 @@ pub struct RevertUniversalTxToken<'info> {
     /// The caller/relayer who pays for the transaction (including executed_sub_tx account creation)
     #[account(mut)]
     pub caller: Signer<'info>,
-
-    /// Vault SOL PDA (needed for gas_fee transfer to caller)
-    #[account(
-        mut,
-        seeds = [VAULT_SEED],
-        bump = config.vault_bump,
-    )]
-    pub vault_sol: SystemAccount<'info>,
 
     pub token_program: Program<'info, Token>,
     pub system_program: Program<'info, System>,
@@ -271,14 +291,25 @@ pub fn revert_universal_tx_token(
         revert_instruction: revert_instruction.clone(),
     });
 
-    // Transfer gas fee to caller (relayer reimbursement)
-    crate::utils::transfer_gas_fee_to_caller(
-        &ctx.accounts.vault_sol.to_account_info(),
-        &ctx.accounts.caller.to_account_info(),
-        &ctx.accounts.system_program.to_account_info(),
-        gas_fee,
-        ctx.accounts.config.vault_bump,
-    )?;
+    // Reimburse relayer gas from fee_vault (not from bridge vault — preserves 1:1 invariant).
+    if gas_fee > 0 {
+        let fee_vault_info = ctx.accounts.fee_vault.to_account_info();
+        let min_balance = Rent::get()?.minimum_balance(FeeVault::LEN);
+        let available = fee_vault_info
+            .lamports()
+            .checked_sub(min_balance)
+            .ok_or(error!(GatewayError::InsufficientFeePool))?;
+        require!(available >= gas_fee, GatewayError::InsufficientFeePool);
+
+        **fee_vault_info.try_borrow_mut_lamports()? -= gas_fee;
+        **ctx.accounts.caller.to_account_info().try_borrow_mut_lamports()? += gas_fee;
+
+        emit!(ProtocolFeeReimbursed {
+            sub_tx_id,
+            relayer: ctx.accounts.caller.key(),
+            amount_lamports: gas_fee,
+        });
+    }
 
     Ok(())
 }

--- a/contracts/svm-gateway/programs/universal-gateway/src/lib.rs
+++ b/contracts/svm-gateway/programs/universal-gateway/src/lib.rs
@@ -68,6 +68,12 @@ pub mod universal_gateway {
         instructions::admin::set_caps_usd(ctx, min_cap, max_cap)
     }
 
+    /// @notice Set flat protocol fee (lamports) for inbound send_universal_tx.
+    /// Not gated by `!config.paused` so the admin can disable fees during an emergency pause.
+    pub fn set_protocol_fee(ctx: Context<FeeVaultAdminAction>, fee_lamports: u64) -> Result<()> {
+        instructions::admin::set_protocol_fee(ctx, fee_lamports)
+    }
+
     /// @notice Set Pyth price feed
     pub fn set_pyth_price_feed(ctx: Context<AdminAction>, price_feed: Pubkey) -> Result<()> {
         instructions::admin::set_pyth_price_feed(ctx, price_feed)
@@ -232,7 +238,7 @@ pub struct GetSolPrice<'info> {
 
 // Re-export account structs and types
 pub use instructions::admin::{
-    AdminAction, PauseAction, RateLimitConfigAction, TokenRateLimitAction,
+    AdminAction, FeeVaultAdminAction, PauseAction, RateLimitConfigAction, TokenRateLimitAction,
 };
 pub use instructions::deposit::SendUniversalTx;
 pub use instructions::execute::FinalizeUniversalTx;
@@ -247,8 +253,12 @@ pub use state::{
     CapsUpdated,
     Config,
     ExecutedSubTx,
+    FeeVault,
     GatewayAccountMeta,
     RevertInstructions,
+    ProtocolFeeCollected,
+    ProtocolFeeReimbursed,
+    ProtocolFeeUpdated,
     TSSAddressUpdated,
     TxType,
     UniversalPayload,
@@ -258,6 +268,7 @@ pub use state::{
     VerificationType,
     CONFIG_SEED,
     EXECUTED_SUB_TX_SEED,
+    FEE_VAULT_SEED,
     FEED_ID,
     VAULT_SEED,
 };

--- a/contracts/svm-gateway/programs/universal-gateway/src/state.rs
+++ b/contracts/svm-gateway/programs/universal-gateway/src/state.rs
@@ -3,6 +3,7 @@ use anchor_lang::prelude::*;
 // PDA seeds
 pub const CONFIG_SEED: &[u8] = b"config";
 pub const VAULT_SEED: &[u8] = b"vault";
+pub const FEE_VAULT_SEED: &[u8] = b"fee_vault";
 pub const TSS_SEED: &[u8] = b"tsspda_v2";
 pub const RATE_LIMIT_CONFIG_SEED: &[u8] = b"rate_limit_config";
 pub const RATE_LIMIT_SEED: &[u8] = b"rate_limit";
@@ -94,6 +95,21 @@ impl Config {
     // discriminator + fields + padding
     // 8 + 32 + 32 + 32 + 16 + 16 + 1 + 1 + 1 + 32 + 8 + 100
     pub const LEN: usize = 8 + 32 + 32 + 32 + 16 + 16 + 1 + 1 + 1 + 32 + 8 + 100;
+}
+
+/// Fee vault: holds protocol fee lamports and the per-tx fee config.
+/// PDA: `[b"fee_vault"]`.
+/// Lamports above rent-exempt minimum = spendable relayer reimbursement pool.
+/// Vault (bridge funds) is never touched by fee logic — 1:1 invariant is structurally enforced.
+#[account]
+pub struct FeeVault {
+    pub protocol_fee_lamports: u64, // Flat fee charged per inbound send_universal_tx; 0 disables
+    pub bump: u8,
+}
+
+impl FeeVault {
+    // 8 (discriminator) + 8 (fee) + 1 (bump) + 50 (padding)
+    pub const LEN: usize = 8 + 8 + 1 + 50;
 }
 
 /// Rate limiting configuration (separate account for backward compatibility)
@@ -229,6 +245,26 @@ pub struct EpochDurationUpdated {
 pub struct TokenRateLimitUpdated {
     pub token_mint: Pubkey,
     pub limit_threshold: u128,
+}
+
+#[event]
+pub struct ProtocolFeeUpdated {
+    pub new_fee_lamports: u64,
+}
+
+#[event]
+pub struct ProtocolFeeCollected {
+    pub payer: Pubkey,
+    pub amount_lamports: u64,
+    pub native_amount_before: u64,
+    pub native_amount_after: u64,
+}
+
+#[event]
+pub struct ProtocolFeeReimbursed {
+    pub sub_tx_id: [u8; 32],
+    pub relayer: Pubkey,
+    pub amount_lamports: u64,
 }
 
 // Keep legacy if referenced; prefer TxWithGas above

--- a/contracts/svm-gateway/tests/admin.test.ts
+++ b/contracts/svm-gateway/tests/admin.test.ts
@@ -319,7 +319,6 @@ describe("Universal Gateway - Admin Functions Tests", () => {
                 .accounts({
                     admin: admin.publicKey,
                     config: configPda,
-                    rateLimitConfig: rateLimitConfigPda,
                     tokenRateLimit: tokenRateLimitPda,
                     tokenMint: mockUSDT.mint.publicKey,
                     systemProgram: SystemProgram.programId,

--- a/contracts/svm-gateway/tests/cea-to-uea.test.ts
+++ b/contracts/svm-gateway/tests/cea-to-uea.test.ts
@@ -90,28 +90,23 @@ describe("Universal Gateway - CEA to UEA Tests", () => {
             gatewayProgram.programId
         );
 
-        // Initialize token rate limits if not already done
+        // Normalize token rate limits so this suite doesn't inherit stale 0-threshold state.
         const veryLargeThreshold = new anchor.BN("1000000000000000000000");
         for (const [pda, mint] of [
             [nativeSolTokenRateLimitPda, PublicKey.default],
             [usdtTokenRateLimitPda, mockUSDT.mint.publicKey],
         ] as [PublicKey, PublicKey][]) {
-            try {
-                await gatewayProgram.account.tokenRateLimit.fetch(pda);
-            } catch {
-                await gatewayProgram.methods
-                    .setTokenRateLimit(veryLargeThreshold)
-                    .accounts({
-                        config: configPda,
-                        rateLimitConfig: rateLimitConfigPda,
-                        tokenRateLimit: pda,
-                        tokenMint: mint,
-                        admin: admin.publicKey,
-                        systemProgram: SystemProgram.programId,
-                    })
-                    .signers([admin])
-                    .rpc();
-            }
+            await gatewayProgram.methods
+                .setTokenRateLimit(veryLargeThreshold)
+                .accounts({
+                    config: configPda,
+                    tokenRateLimit: pda,
+                    tokenMint: mint,
+                    admin: admin.publicKey,
+                    systemProgram: SystemProgram.programId,
+                })
+                .signers([admin])
+                .rpc();
         }
 
         // Get vault ATA and create if needed

--- a/contracts/svm-gateway/tests/execute.test.ts
+++ b/contracts/svm-gateway/tests/execute.test.ts
@@ -275,28 +275,23 @@ describe("Universal Gateway - Execute Tests", () => {
             gatewayProgram.programId
         );
 
-        // Ensure token rate limit accounts exist for CEA->UEA self-call tests.
+        // Normalize token rate limit accounts so tests don't inherit stale 0-threshold state.
         const veryLargeThreshold = new anchor.BN("1000000000000000000000");
         for (const [pda, mint] of [
             [nativeSolTokenRateLimitPda, PublicKey.default],
             [usdtTokenRateLimitPda, mockUSDT.mint.publicKey],
         ] as [PublicKey, PublicKey][]) {
-            try {
-                await gatewayProgram.account.tokenRateLimit.fetch(pda);
-            } catch {
-                await gatewayProgram.methods
-                    .setTokenRateLimit(veryLargeThreshold)
-                    .accounts({
-                        config: configPda,
-                        rateLimitConfig: rateLimitConfigPda,
-                        tokenRateLimit: pda,
-                        tokenMint: mint,
-                        admin: admin.publicKey,
-                        systemProgram: SystemProgram.programId,
-                    })
-                    .signers([admin])
-                    .rpc();
-            }
+            await gatewayProgram.methods
+                .setTokenRateLimit(veryLargeThreshold)
+                .accounts({
+                    config: configPda,
+                    tokenRateLimit: pda,
+                    tokenMint: mint,
+                    admin: admin.publicKey,
+                    systemProgram: SystemProgram.programId,
+                })
+                .signers([admin])
+                .rpc();
         }
 
         // Get vault ATA and create if needed (admin pays)

--- a/contracts/svm-gateway/tests/helpers/test-setup.ts
+++ b/contracts/svm-gateway/tests/helpers/test-setup.ts
@@ -73,7 +73,20 @@ export async function ensureTestSetup(): Promise<void> {
         // Step 4: Derive program PDAs
         const [configPda] = PublicKey.findProgramAddressSync([Buffer.from("config")], program.programId);
         const [vaultPda] = PublicKey.findProgramAddressSync([Buffer.from("vault")], program.programId);
+        const [feeVaultPda] = PublicKey.findProgramAddressSync([Buffer.from("fee_vault")], program.programId);
         const [rateLimitConfigPda] = PublicKey.findProgramAddressSync([Buffer.from("rate_limit_config")], program.programId);
+        const [nativeTokenRateLimitPda] = PublicKey.findProgramAddressSync(
+            [Buffer.from("rate_limit"), PublicKey.default.toBuffer()],
+            program.programId
+        );
+        const [usdtTokenRateLimitPda] = PublicKey.findProgramAddressSync(
+            [Buffer.from("rate_limit"), mockUSDT.mint.publicKey.toBuffer()],
+            program.programId
+        );
+        const [usdcTokenRateLimitPda] = PublicKey.findProgramAddressSync(
+            [Buffer.from("rate_limit"), mockUSDC.mint.publicKey.toBuffer()],
+            program.programId
+        );
 
         // Step 5: Setup mock Pyth price feed
         let mockPriceFeed: PublicKey;
@@ -162,8 +175,50 @@ export async function ensureTestSetup(): Promise<void> {
                 .signers([admin])
                 .rpc();
         }
+
+        // Step 9: Ensure fee_vault exists (devnet-safe path) and starts disabled
+        await program.methods
+            .setProtocolFee(new anchor.BN(0))
+            .accounts({
+                config: configPda,
+                feeVault: feeVaultPda,
+                admin: admin.publicKey,
+                systemProgram: SystemProgram.programId,
+            })
+            .signers([admin])
+            .rpc();
+
+        // Step 10: Normalize rate-limit state so suites don't inherit stale 0-threshold config
+        await program.methods
+            .updateEpochDuration(new anchor.BN(0))
+            .accounts({
+                admin: admin.publicKey,
+                config: configPda,
+                rateLimitConfig: rateLimitConfigPda,
+                systemProgram: SystemProgram.programId,
+            })
+            .signers([admin])
+            .rpc();
+
+        const veryLargeThreshold = new anchor.BN("1000000000000000000000");
+        for (const [tokenMint, tokenRateLimit] of [
+            [PublicKey.default, nativeTokenRateLimitPda],
+            [mockUSDT.mint.publicKey, usdtTokenRateLimitPda],
+            [mockUSDC.mint.publicKey, usdcTokenRateLimitPda],
+        ] as const) {
+            await program.methods
+                .setTokenRateLimit(veryLargeThreshold)
+                .accounts({
+                    admin: admin.publicKey,
+                    config: configPda,
+                    tokenRateLimit,
+                    tokenMint,
+                    systemProgram: SystemProgram.programId,
+                })
+                .signers([admin])
+                .rpc();
+        }
     })();
 
     return setupPromise;
 }
-

--- a/contracts/svm-gateway/tests/helpers/test-utils.ts
+++ b/contracts/svm-gateway/tests/helpers/test-utils.ts
@@ -77,6 +77,14 @@ export const getCeaAuthorityPda = (sender: number[], programId: PublicKey): Publ
     return pda;
 };
 
+export const getFeeVaultPda = (programId: PublicKey): PublicKey => {
+    const [pda] = PublicKey.findProgramAddressSync(
+        [Buffer.from("fee_vault")],
+        programId
+    );
+    return pda;
+};
+
 export const getTokenRateLimitPda = (tokenMint: PublicKey, programId: PublicKey): PublicKey => {
     const [pda] = PublicKey.findProgramAddressSync(
         [Buffer.from("rate_limit"), tokenMint.toBuffer()],

--- a/contracts/svm-gateway/tests/rate-limit.test.ts
+++ b/contracts/svm-gateway/tests/rate-limit.test.ts
@@ -21,6 +21,7 @@ describe("Universal Gateway - Rate Limiting Tests", () => {
     let user1: Keypair;
     let configPda: PublicKey;
     let vaultPda: PublicKey;
+    let feeVaultPda: PublicKey;
     let rateLimitConfigPda: PublicKey;
     let mockPriceFeed: PublicKey;
     let solPrice: number;
@@ -51,33 +52,27 @@ describe("Universal Gateway - Rate Limiting Tests", () => {
 
         [configPda] = PublicKey.findProgramAddressSync([Buffer.from("config")], program.programId);
         [vaultPda] = PublicKey.findProgramAddressSync([Buffer.from("vault")], program.programId);
+        [feeVaultPda] = PublicKey.findProgramAddressSync([Buffer.from("fee_vault")], program.programId);
         [rateLimitConfigPda] = PublicKey.findProgramAddressSync([Buffer.from("rate_limit_config")], program.programId);
 
         mockPriceFeed = sharedState.getMockPriceFeed();
         solPrice = await getSolPrice(mockPriceFeed);
         mockUSDT = sharedState.getMockUSDT();
 
-        // Initialize token rate limit accounts (required for universal gateway)
+        // Normalize native token rate limit so this suite starts from a supported token state.
         const veryLargeThreshold = new anchor.BN("1000000000000000000000"); // 1 sextillion (effectively unlimited)
         const nativeSolTokenRateLimitPda = getTokenRateLimitPda(PublicKey.default);
-
-        try {
-            await program.account.tokenRateLimit.fetch(nativeSolTokenRateLimitPda);
-        } catch {
-            // Not initialized, create it
-            await program.methods
-                .setTokenRateLimit(veryLargeThreshold)
-                .accounts({
-                    admin: admin.publicKey,
-                    config: configPda,
-                    rateLimitConfig: rateLimitConfigPda,
-                    tokenRateLimit: nativeSolTokenRateLimitPda,
-                    tokenMint: PublicKey.default,
-                    systemProgram: SystemProgram.programId,
-                })
-                .signers([admin])
-                .rpc();
-        }
+        await program.methods
+            .setTokenRateLimit(veryLargeThreshold)
+            .accounts({
+                admin: admin.publicKey,
+                config: configPda,
+                tokenRateLimit: nativeSolTokenRateLimitPda,
+                tokenMint: PublicKey.default,
+                systemProgram: SystemProgram.programId,
+            })
+            .signers([admin])
+            .rpc();
     });
 
     describe("Block USD Cap Enforcement", () => {
@@ -119,6 +114,7 @@ describe("Universal Gateway - Rate Limiting Tests", () => {
                 .accounts({
                     config: configPda,
                     vault: vaultPda,
+                    feeVault: feeVaultPda,
                     userTokenAccount: vaultPda,
                     gatewayTokenAccount: vaultPda,
                     user: user1.publicKey,
@@ -157,6 +153,7 @@ describe("Universal Gateway - Rate Limiting Tests", () => {
                     .accounts({
                         config: configPda,
                         vault: vaultPda,
+                        feeVault: feeVaultPda,
                         userTokenAccount: vaultPda,
                         gatewayTokenAccount: vaultPda,
                         user: user1.publicKey,
@@ -269,6 +266,7 @@ describe("Universal Gateway - Rate Limiting Tests", () => {
                 .accounts({
                     config: configPda,
                     vault: vaultPda,
+                    feeVault: feeVaultPda,
                     userTokenAccount: vaultPda,
                     gatewayTokenAccount: vaultPda,
                     user: user1.publicKey,
@@ -294,6 +292,7 @@ describe("Universal Gateway - Rate Limiting Tests", () => {
                 .accounts({
                     config: configPda,
                     vault: vaultPda,
+                    feeVault: feeVaultPda,
                     userTokenAccount: vaultPda,
                     gatewayTokenAccount: vaultPda,
                     user: user1.publicKey,
@@ -366,6 +365,7 @@ describe("Universal Gateway - Rate Limiting Tests", () => {
                 .accounts({
                     config: configPda,
                     vault: vaultPda,
+                    feeVault: feeVaultPda,
                     userTokenAccount: vaultPda,
                     gatewayTokenAccount: vaultPda,
                     user: user1.publicKey,
@@ -384,6 +384,7 @@ describe("Universal Gateway - Rate Limiting Tests", () => {
                 .accounts({
                     config: configPda,
                     vault: vaultPda,
+                    feeVault: feeVaultPda,
                     userTokenAccount: vaultPda,
                     gatewayTokenAccount: vaultPda,
                     user: user1.publicKey,
@@ -421,7 +422,6 @@ describe("Universal Gateway - Rate Limiting Tests", () => {
                 .accounts({
                     admin: admin.publicKey,
                     config: configPda,
-                    rateLimitConfig: rateLimitConfigPda,
                     tokenRateLimit: nativeSolTokenRateLimitPda,
                     tokenMint: PublicKey.default,
                     systemProgram: SystemProgram.programId,
@@ -445,6 +445,7 @@ describe("Universal Gateway - Rate Limiting Tests", () => {
                 .accounts({
                     config: configPda,
                     vault: vaultPda,
+                    feeVault: feeVaultPda,
                     userTokenAccount: vaultPda,
                     gatewayTokenAccount: vaultPda,
                     user: user1.publicKey,
@@ -472,6 +473,7 @@ describe("Universal Gateway - Rate Limiting Tests", () => {
                 .accounts({
                     config: configPda,
                     vault: vaultPda,
+                    feeVault: feeVaultPda,
                     userTokenAccount: vaultPda,
                     gatewayTokenAccount: vaultPda,
                     user: user1.publicKey,
@@ -501,6 +503,7 @@ describe("Universal Gateway - Rate Limiting Tests", () => {
                     .accounts({
                         config: configPda,
                         vault: vaultPda,
+                        feeVault: feeVaultPda,
                         userTokenAccount: vaultPda,
                         gatewayTokenAccount: vaultPda,
                         user: user1.publicKey,
@@ -534,7 +537,6 @@ describe("Universal Gateway - Rate Limiting Tests", () => {
                 .accounts({
                     admin: admin.publicKey,
                     config: configPda,
-                    rateLimitConfig: rateLimitConfigPda,
                     tokenRateLimit: usdtTokenRateLimitPda,
                     tokenMint: mockUSDT.mint.publicKey,
                     systemProgram: SystemProgram.programId,
@@ -558,6 +560,7 @@ describe("Universal Gateway - Rate Limiting Tests", () => {
                 .accounts({
                     config: configPda,
                     vault: vaultPda,
+                    feeVault: feeVaultPda,
                     userTokenAccount: userTokenAccount,
                     gatewayTokenAccount: gatewayTokenAccount,
                     user: user1.publicKey,
@@ -585,6 +588,7 @@ describe("Universal Gateway - Rate Limiting Tests", () => {
                 .accounts({
                     config: configPda,
                     vault: vaultPda,
+                    feeVault: feeVaultPda,
                     userTokenAccount: userTokenAccount,
                     gatewayTokenAccount: gatewayTokenAccount,
                     user: user1.publicKey,
@@ -614,6 +618,7 @@ describe("Universal Gateway - Rate Limiting Tests", () => {
                     .accounts({
                         config: configPda,
                         vault: vaultPda,
+                        feeVault: feeVaultPda,
                         userTokenAccount: userTokenAccount,
                         gatewayTokenAccount: gatewayTokenAccount,
                         user: user1.publicKey,
@@ -641,7 +646,6 @@ describe("Universal Gateway - Rate Limiting Tests", () => {
                 .accounts({
                     admin: admin.publicKey,
                     config: configPda,
-                    rateLimitConfig: rateLimitConfigPda,
                     tokenRateLimit: nativeSolTokenRateLimitPda,
                     tokenMint: PublicKey.default,
                     systemProgram: SystemProgram.programId,
@@ -666,6 +670,7 @@ describe("Universal Gateway - Rate Limiting Tests", () => {
                     .accounts({
                         config: configPda,
                         vault: vaultPda,
+                        feeVault: feeVaultPda,
                         userTokenAccount: vaultPda,
                         gatewayTokenAccount: vaultPda,
                         user: user1.publicKey,
@@ -706,7 +711,6 @@ describe("Universal Gateway - Rate Limiting Tests", () => {
                 .accounts({
                     admin: admin.publicKey,
                     config: configPda,
-                    rateLimitConfig: rateLimitConfigPda,
                     tokenRateLimit: nativeSolTokenRateLimitPda,
                     tokenMint: PublicKey.default,
                     systemProgram: SystemProgram.programId,
@@ -733,6 +737,7 @@ describe("Universal Gateway - Rate Limiting Tests", () => {
                 .accounts({
                     config: configPda,
                     vault: vaultPda,
+                    feeVault: feeVaultPda,
                     userTokenAccount: vaultPda,
                     gatewayTokenAccount: vaultPda,
                     user: user1.publicKey,
@@ -769,7 +774,6 @@ describe("Universal Gateway - Rate Limiting Tests", () => {
                 .accounts({
                     admin: admin.publicKey,
                     config: configPda,
-                    rateLimitConfig: rateLimitConfigPda,
                     tokenRateLimit: nativeSolTokenRateLimitPda,
                     tokenMint: PublicKey.default,
                     systemProgram: SystemProgram.programId,
@@ -799,6 +803,7 @@ describe("Universal Gateway - Rate Limiting Tests", () => {
                 .accounts({
                     config: configPda,
                     vault: vaultPda,
+                    feeVault: feeVaultPda,
                     userTokenAccount: vaultPda,
                     gatewayTokenAccount: vaultPda,
                     user: user1.publicKey,
@@ -827,6 +832,7 @@ describe("Universal Gateway - Rate Limiting Tests", () => {
                     .accounts({
                         config: configPda,
                         vault: vaultPda,
+                        feeVault: feeVaultPda,
                         userTokenAccount: vaultPda,
                         gatewayTokenAccount: vaultPda,
                         user: user1.publicKey,
@@ -881,7 +887,6 @@ describe("Universal Gateway - Rate Limiting Tests", () => {
                 .accounts({
                     admin: admin.publicKey,
                     config: configPda,
-                    rateLimitConfig: rateLimitConfigPda,
                     tokenRateLimit: nativeSolTokenRateLimitPda,
                     tokenMint: PublicKey.default,
                     systemProgram: SystemProgram.programId,
@@ -893,4 +898,3 @@ describe("Universal Gateway - Rate Limiting Tests", () => {
         }
     });
 });
-

--- a/contracts/svm-gateway/tests/universal-tx.test.ts
+++ b/contracts/svm-gateway/tests/universal-tx.test.ts
@@ -1,7 +1,12 @@
 import * as anchor from "@coral-xyz/anchor";
 import { Program } from "@coral-xyz/anchor";
 import { UniversalGateway } from "../target/types/universal_gateway";
-import { PublicKey, Keypair, SystemProgram, LAMPORTS_PER_SOL } from "@solana/web3.js";
+import {
+  PublicKey,
+  Keypair,
+  SystemProgram,
+  LAMPORTS_PER_SOL,
+} from "@solana/web3.js";
 import { expect } from "chai";
 import * as sharedState from "./shared-state";
 import { getSolPrice, calculateSolAmount } from "./setup-pricefeed";
@@ -9,906 +14,1197 @@ import * as spl from "@solana/spl-token";
 import { ensureTestSetup } from "./helpers/test-setup";
 
 describe("Universal Gateway - send_universal_tx Tests", () => {
-    anchor.setProvider(anchor.AnchorProvider.env());
-    const provider = anchor.getProvider() as anchor.AnchorProvider;
-    const program = anchor.workspace.UniversalGateway as Program<UniversalGateway>;
+  anchor.setProvider(anchor.AnchorProvider.env());
+  const provider = anchor.getProvider() as anchor.AnchorProvider;
+  const program = anchor.workspace
+    .UniversalGateway as Program<UniversalGateway>;
 
-    before(async () => {
-        await ensureTestSetup();
+  before(async () => {
+    await ensureTestSetup();
+  });
+
+  let admin: Keypair;
+  let tssAddress: Keypair;
+  let pauser: Keypair;
+  let user1: Keypair;
+  let user2: Keypair;
+  let configPda: PublicKey;
+  let vaultPda: PublicKey;
+  let feeVaultPda: PublicKey;
+  let rateLimitConfigPda: PublicKey;
+  let mockPriceFeed: PublicKey;
+  let solPrice: number;
+  let mockUSDT: any;
+  let mockUSDC: any;
+  const DEFAULT_PROTOCOL_FEE_LAMPORTS = 50_000;
+
+  // Helper to create payload (EVM-style: to address, value, calldata, gas params).
+  const createPayload = (
+    to: number,
+    vType: any = { signedVerification: {} }
+  ) => ({
+    to: Array.from(Buffer.alloc(20, to)),
+    value: new anchor.BN(0),
+    data: Buffer.from([]),
+    gasLimit: new anchor.BN(21000),
+    maxFeePerGas: new anchor.BN(20000000000),
+    maxPriorityFeePerGas: new anchor.BN(1000000000),
+    nonce: new anchor.BN(0),
+    deadline: new anchor.BN(Math.floor(Date.now() / 1000) + 3600),
+    vType,
+  });
+
+  /**
+   * Serialize payload as Anchor/Borsh-encoded UniversalPayload (matches program state.rs).
+   * EVM relayer decodes the same format on Push chain. Smaller than JSON.
+   */
+  const serializePayload = (payload: any): Buffer => {
+    // to: exactly 20 bytes (EVM address), match Rust [u8; 20]
+    const toRaw = Buffer.from(new Uint8Array(payload.to));
+    const toBuf = Buffer.alloc(20);
+    toRaw.copy(toBuf, 0, 0, Math.min(20, toRaw.length));
+    const data = Buffer.isBuffer(payload.data)
+      ? payload.data
+      : Buffer.from(payload.data ?? []);
+    const value = BigInt(payload.value.toString());
+    const gasLimit = BigInt(payload.gasLimit.toString());
+    const maxFeePerGas = BigInt(payload.maxFeePerGas.toString());
+    const maxPriorityFeePerGas = BigInt(
+      payload.maxPriorityFeePerGas.toString()
+    );
+    const nonce = BigInt(payload.nonce.toString());
+    const deadline = BigInt(payload.deadline.toString());
+    const vTypeDiscriminant =
+      payload.vType?.signedVerification !== undefined ? 0 : 1;
+
+    const dataLen = data.length;
+    const size = 20 + 8 + 4 + dataLen + 8 + 8 + 8 + 8 + 8 + 1;
+    const buf = Buffer.alloc(size);
+    let off = 0;
+    toBuf.copy(buf, off);
+    off += 20;
+    buf.writeBigUInt64LE(value, off);
+    off += 8;
+    buf.writeUInt32LE(dataLen, off);
+    off += 4;
+    data.copy(buf, off);
+    off += dataLen;
+    buf.writeBigUInt64LE(gasLimit, off);
+    off += 8;
+    buf.writeBigUInt64LE(maxFeePerGas, off);
+    off += 8;
+    buf.writeBigUInt64LE(maxPriorityFeePerGas, off);
+    off += 8;
+    buf.writeBigUInt64LE(nonce, off);
+    off += 8;
+    buf.writeBigInt64LE(deadline, off);
+    off += 8;
+    buf.writeUInt8(vTypeDiscriminant, off);
+    return buf;
+  };
+
+  // Helper to create revert instruction
+  const createRevertInstruction = (
+    recipient: PublicKey,
+    msg: string = "test"
+  ) => ({
+    fundRecipient: recipient,
+    revertMsg: Buffer.from(msg),
+  });
+
+  // Helper to get token rate limit PDA
+  const getTokenRateLimitPda = (tokenMint: PublicKey): PublicKey => {
+    const [pda] = PublicKey.findProgramAddressSync(
+      [Buffer.from("rate_limit"), tokenMint.toBuffer()],
+      program.programId
+    );
+    return pda;
+  };
+
+  const setProtocolFee = async (feeLamports: number) => {
+    await program.methods
+      .setProtocolFee(new anchor.BN(feeLamports))
+      .accounts({
+        config: configPda,
+        feeVault: feeVaultPda,
+        admin: admin.publicKey,
+        systemProgram: SystemProgram.programId,
+      })
+      .signers([admin])
+      .rpc();
+  };
+
+  const withProtocolFee = (baseLamports: number) =>
+    new anchor.BN(baseLamports + DEFAULT_PROTOCOL_FEE_LAMPORTS);
+
+  before(async () => {
+    admin = sharedState.getAdmin();
+    tssAddress = sharedState.getTssAddress();
+    pauser = sharedState.getPauser();
+    user1 = Keypair.generate();
+    user2 = Keypair.generate();
+
+    const airdropAmount = 20 * LAMPORTS_PER_SOL;
+    await Promise.all([
+      provider.connection.requestAirdrop(user1.publicKey, airdropAmount),
+      provider.connection.requestAirdrop(user2.publicKey, airdropAmount),
+    ]);
+    await new Promise((resolve) => setTimeout(resolve, 2000));
+
+    [configPda] = PublicKey.findProgramAddressSync(
+      [Buffer.from("config")],
+      program.programId
+    );
+    [vaultPda] = PublicKey.findProgramAddressSync(
+      [Buffer.from("vault")],
+      program.programId
+    );
+    [feeVaultPda] = PublicKey.findProgramAddressSync(
+      [Buffer.from("fee_vault")],
+      program.programId
+    );
+    [rateLimitConfigPda] = PublicKey.findProgramAddressSync(
+      [Buffer.from("rate_limit_config")],
+      program.programId
+    );
+
+    mockPriceFeed = sharedState.getMockPriceFeed();
+    solPrice = await getSolPrice(mockPriceFeed);
+
+    // Get mock tokens
+    mockUSDT = sharedState.getMockUSDT();
+    mockUSDC = sharedState.getMockUSDC();
+
+    // Normalize token rate limits every run so this suite doesn't inherit stale 0-threshold state.
+    const veryLargeThreshold = new anchor.BN("1000000000000000000000"); // 1 sextillion
+    for (const tokenMint of [
+      PublicKey.default,
+      mockUSDT.mint.publicKey,
+      mockUSDC.mint.publicKey,
+    ]) {
+      await program.methods
+        .setTokenRateLimit(veryLargeThreshold)
+        .accounts({
+          admin: admin.publicKey,
+          config: configPda,
+          tokenRateLimit: getTokenRateLimitPda(tokenMint),
+          tokenMint,
+          systemProgram: SystemProgram.programId,
+        })
+        .signers([admin])
+        .rpc();
+    }
+
+    await setProtocolFee(DEFAULT_PROTOCOL_FEE_LAMPORTS);
+  });
+
+  describe("GAS Route (TxType.GAS)", () => {
+    it("Should deposit native SOL as gas without payload", async () => {
+      const gasAmount = calculateSolAmount(2.5, solPrice);
+      const initialVaultBalance = await provider.connection.getBalance(vaultPda);
+      const initialFeeVaultBalance = await provider.connection.getBalance(feeVaultPda);
+      const initialUserBalance = await provider.connection.getBalance(user1.publicKey);
+
+      const nativeSolTokenRateLimitPda = getTokenRateLimitPda(
+        PublicKey.default
+      );
+
+      const req = {
+        recipient: Array.from(Buffer.alloc(20, 0)),
+        token: PublicKey.default,
+        amount: new anchor.BN(0),
+        payload: Buffer.from([]),
+        revertInstruction: createRevertInstruction(user1.publicKey),
+        signatureData: Buffer.from("gas_sig"),
+      };
+
+      await program.methods
+        .sendUniversalTx(req, withProtocolFee(gasAmount))
+        .accounts({
+          config: configPda,
+          vault: vaultPda,
+          feeVault: feeVaultPda,
+          userTokenAccount: vaultPda, // Dummy account for native SOL routes
+          gatewayTokenAccount: vaultPda, // Dummy account for native SOL routes
+          user: user1.publicKey,
+          priceUpdate: mockPriceFeed,
+          rateLimitConfig: rateLimitConfigPda,
+          tokenRateLimit: nativeSolTokenRateLimitPda,
+          tokenProgram: spl.TOKEN_PROGRAM_ID,
+          systemProgram: SystemProgram.programId,
+        })
+        .signers([user1])
+        .rpc();
+
+      const finalVaultBalance = await provider.connection.getBalance(vaultPda);
+      const finalFeeVaultBalance = await provider.connection.getBalance(feeVaultPda);
+      // Bridge vault receives only the gas amount; fee goes to fee_vault (1:1 invariant)
+      expect(finalVaultBalance - initialVaultBalance).to.equal(gasAmount);
+      expect(finalFeeVaultBalance - initialFeeVaultBalance).to.equal(DEFAULT_PROTOCOL_FEE_LAMPORTS);
     });
 
-    let admin: Keypair;
-    let tssAddress: Keypair;
-    let pauser: Keypair;
-    let user1: Keypair;
-    let user2: Keypair;
-    let configPda: PublicKey;
-    let vaultPda: PublicKey;
-    let rateLimitConfigPda: PublicKey;
-    let mockPriceFeed: PublicKey;
-    let solPrice: number;
-    let mockUSDT: any;
-    let mockUSDC: any;
+    it("Should route GAS request with payload to GAS_AND_PAYLOAD (not reject)", async () => {
+      // NOTE: This test verifies the correct behavior - amount==0 + payload>0 routes to GAS_AND_PAYLOAD
+      // The payload validation is commented out in send_tx_with_gas_route (matching EVM V0)
+      const gasAmount = calculateSolAmount(2.5, solPrice);
+      const nativeSolTokenRateLimitPda = getTokenRateLimitPda(
+        PublicKey.default
+      );
+      const initialVaultBalance = await provider.connection.getBalance(
+        vaultPda
+      );
 
-    // Helper to create payload (EVM-style: to address, value, calldata, gas params).
-    const createPayload = (to: number, vType: any = { signedVerification: {} }) => ({
-        to: Array.from(Buffer.alloc(20, to)),
-        value: new anchor.BN(0),
-        data: Buffer.from([]),
-        gasLimit: new anchor.BN(21000),
-        maxFeePerGas: new anchor.BN(20000000000),
-        maxPriorityFeePerGas: new anchor.BN(1000000000),
-        nonce: new anchor.BN(0),
-        deadline: new anchor.BN(Math.floor(Date.now() / 1000) + 3600),
-        vType,
+      const req = {
+        recipient: Array.from(Buffer.alloc(20, 0)),
+        token: PublicKey.default,
+        amount: new anchor.BN(0),
+        payload: serializePayload(createPayload(99)), // Non-empty payload
+        revertInstruction: createRevertInstruction(user1.publicKey),
+        signatureData: Buffer.from("sig"),
+      };
+
+      // Should succeed and route to GAS_AND_PAYLOAD (fetchTxType logic)
+      await program.methods
+        .sendUniversalTx(req, withProtocolFee(gasAmount))
+        .accounts({
+          config: configPda,
+          vault: vaultPda,
+          feeVault: feeVaultPda,
+          userTokenAccount: vaultPda, // Correct: use vaultPda as dummy for native SOL
+          gatewayTokenAccount: vaultPda, // Correct: use vaultPda as dummy for native SOL
+          user: user1.publicKey,
+          priceUpdate: mockPriceFeed,
+          rateLimitConfig: rateLimitConfigPda,
+          tokenRateLimit: nativeSolTokenRateLimitPda,
+          tokenProgram: spl.TOKEN_PROGRAM_ID,
+          systemProgram: SystemProgram.programId,
+        })
+        .signers([user1])
+        .rpc();
+
+      // Verify transaction succeeded (vault receives only gas; fee goes to fee_vault)
+      const finalVaultBalance = await provider.connection.getBalance(vaultPda);
+      expect(finalVaultBalance - initialVaultBalance).to.equal(gasAmount);
+    });
+  });
+
+  describe("GAS_AND_PAYLOAD Route", () => {
+    it("Should deposit gas with payload", async () => {
+      const gasAmount = calculateSolAmount(2.5, solPrice);
+      const initialVaultBalance = await provider.connection.getBalance(
+        vaultPda
+      );
+      const nativeSolTokenRateLimitPda = getTokenRateLimitPda(
+        PublicKey.default
+      );
+
+      const req = {
+        recipient: Array.from(Buffer.alloc(20, 0)),
+        token: PublicKey.default,
+        amount: new anchor.BN(0),
+        payload: serializePayload(createPayload(1)),
+        revertInstruction: createRevertInstruction(user1.publicKey),
+        signatureData: Buffer.from("gas_payload_sig"),
+      };
+
+      await program.methods
+        .sendUniversalTx(req, withProtocolFee(gasAmount))
+        .accounts({
+          config: configPda,
+          vault: vaultPda,
+          feeVault: feeVaultPda,
+          userTokenAccount: vaultPda, // Dummy account for native SOL routes
+          gatewayTokenAccount: vaultPda, // Dummy account for native SOL routes
+          user: user1.publicKey,
+          priceUpdate: mockPriceFeed,
+          rateLimitConfig: rateLimitConfigPda,
+          tokenRateLimit: nativeSolTokenRateLimitPda,
+          tokenProgram: spl.TOKEN_PROGRAM_ID,
+          systemProgram: SystemProgram.programId,
+        })
+        .signers([user1])
+        .rpc();
+
+      const finalVaultBalance = await provider.connection.getBalance(vaultPda);
+      expect(finalVaultBalance - initialVaultBalance).to.equal(gasAmount);
     });
 
-    /**
-     * Serialize payload as Anchor/Borsh-encoded UniversalPayload (matches program state.rs).
-     * EVM relayer decodes the same format on Push chain. Smaller than JSON.
-     */
-    const serializePayload = (payload: any): Buffer => {
-        // to: exactly 20 bytes (EVM address), match Rust [u8; 20]
-        const toRaw = Buffer.from(new Uint8Array(payload.to));
-        const toBuf = Buffer.alloc(20);
-        toRaw.copy(toBuf, 0, 0, Math.min(20, toRaw.length));
-        const data = Buffer.isBuffer(payload.data) ? payload.data : Buffer.from(payload.data ?? []);
-        const value = BigInt(payload.value.toString());
-        const gasLimit = BigInt(payload.gasLimit.toString());
-        const maxFeePerGas = BigInt(payload.maxFeePerGas.toString());
-        const maxPriorityFeePerGas = BigInt(payload.maxPriorityFeePerGas.toString());
-        const nonce = BigInt(payload.nonce.toString());
-        const deadline = BigInt(payload.deadline.toString());
-        const vTypeDiscriminant = payload.vType?.signedVerification !== undefined ? 0 : 1;
+    it("Should allow payload-only execution (gas_amount == 0)", async () => {
+      const nativeSolTokenRateLimitPda = getTokenRateLimitPda(
+        PublicKey.default
+      );
 
-        const dataLen = data.length;
-        const size = 20 + 8 + 4 + dataLen + 8 + 8 + 8 + 8 + 8 + 1;
-        const buf = Buffer.alloc(size);
-        let off = 0;
-        toBuf.copy(buf, off);
-        off += 20;
-        buf.writeBigUInt64LE(value, off);
-        off += 8;
-        buf.writeUInt32LE(dataLen, off);
-        off += 4;
-        data.copy(buf, off);
-        off += dataLen;
-        buf.writeBigUInt64LE(gasLimit, off);
-        off += 8;
-        buf.writeBigUInt64LE(maxFeePerGas, off);
-        off += 8;
-        buf.writeBigUInt64LE(maxPriorityFeePerGas, off);
-        off += 8;
-        buf.writeBigUInt64LE(nonce, off);
-        off += 8;
-        buf.writeBigInt64LE(deadline, off);
-        off += 8;
-        buf.writeUInt8(vTypeDiscriminant, off);
-        return buf;
-    };
+      const req = {
+        recipient: Array.from(Buffer.alloc(20, 0)),
+        token: PublicKey.default,
+        amount: new anchor.BN(0),
+        payload: serializePayload(createPayload(1)),
+        revertInstruction: createRevertInstruction(user1.publicKey),
+        signatureData: Buffer.from("payload_only"),
+      };
 
-    // Helper to create revert instruction
-    const createRevertInstruction = (recipient: PublicKey, msg: string = "test") => ({
-        fundRecipient: recipient,
-        revertMsg: Buffer.from(msg),
+      // Should succeed with 0 native amount
+      await program.methods
+        .sendUniversalTx(req, withProtocolFee(0))
+        .accounts({
+          config: configPda,
+          vault: vaultPda,
+          feeVault: feeVaultPda,
+          userTokenAccount: vaultPda, // Dummy account for native SOL routes
+          gatewayTokenAccount: vaultPda, // Dummy account for native SOL routes
+          user: user1.publicKey,
+          priceUpdate: mockPriceFeed,
+          rateLimitConfig: rateLimitConfigPda,
+          tokenRateLimit: nativeSolTokenRateLimitPda,
+          tokenProgram: spl.TOKEN_PROGRAM_ID,
+          systemProgram: SystemProgram.programId,
+        })
+        .signers([user1])
+        .rpc();
+    });
+  });
+
+  describe("FUNDS Route - Native SOL", () => {
+    it("Should bridge native SOL funds", async () => {
+      const fundsAmount = 0.5 * LAMPORTS_PER_SOL;
+      const initialVaultBalance = await provider.connection.getBalance(
+        vaultPda
+      );
+      const nativeSolTokenRateLimitPda = getTokenRateLimitPda(
+        PublicKey.default
+      );
+
+      const req = {
+        recipient: Array.from(Buffer.alloc(20, 0)), // Must be zero for FUNDS
+        token: PublicKey.default,
+        amount: new anchor.BN(fundsAmount),
+        payload: Buffer.from([]),
+        revertInstruction: createRevertInstruction(user1.publicKey),
+        signatureData: Buffer.from("funds_sig"),
+      };
+
+      await program.methods
+        .sendUniversalTx(req, withProtocolFee(fundsAmount))
+        .accounts({
+          config: configPda,
+          vault: vaultPda,
+          feeVault: feeVaultPda,
+          userTokenAccount: vaultPda, // Dummy account for native SOL routes
+          gatewayTokenAccount: vaultPda, // Dummy account for native SOL routes
+          user: user1.publicKey,
+          priceUpdate: mockPriceFeed,
+          rateLimitConfig: rateLimitConfigPda,
+          tokenRateLimit: nativeSolTokenRateLimitPda,
+          tokenProgram: spl.TOKEN_PROGRAM_ID,
+          systemProgram: SystemProgram.programId,
+        })
+        .signers([user1])
+        .rpc();
+
+      const finalVaultBalance = await provider.connection.getBalance(vaultPda);
+      expect(finalVaultBalance - initialVaultBalance).to.equal(fundsAmount);
     });
 
-    // Helper to get token rate limit PDA
-    const getTokenRateLimitPda = (tokenMint: PublicKey): PublicKey => {
-        const [pda] = PublicKey.findProgramAddressSync(
-            [Buffer.from("rate_limit"), tokenMint.toBuffer()],
-            program.programId
+    it("Should bridge native SOL funds to explicit recipient", async () => {
+      const fundsAmount = 0.75 * LAMPORTS_PER_SOL;
+      const initialVaultBalance = await provider.connection.getBalance(
+        vaultPda
+      );
+      const nativeSolTokenRateLimitPda = getTokenRateLimitPda(
+        PublicKey.default
+      );
+
+      const req = {
+        recipient: Array.from(Buffer.alloc(20, 1)), // Non-zero recipient now allowed
+        token: PublicKey.default,
+        amount: new anchor.BN(fundsAmount),
+        payload: Buffer.from([]),
+        revertInstruction: createRevertInstruction(user1.publicKey),
+        signatureData: Buffer.from("funds_nonzero_recipient"),
+      };
+
+      await program.methods
+        .sendUniversalTx(req, withProtocolFee(fundsAmount))
+        .accounts({
+          config: configPda,
+          vault: vaultPda,
+          feeVault: feeVaultPda,
+          userTokenAccount: vaultPda,
+          gatewayTokenAccount: vaultPda,
+          user: user1.publicKey,
+          priceUpdate: mockPriceFeed,
+          rateLimitConfig: rateLimitConfigPda,
+          tokenRateLimit: nativeSolTokenRateLimitPda,
+          tokenProgram: spl.TOKEN_PROGRAM_ID,
+          systemProgram: SystemProgram.programId,
+        })
+        .signers([user1])
+        .rpc();
+
+      const finalVaultBalance = await provider.connection.getBalance(vaultPda);
+      expect(finalVaultBalance - initialVaultBalance).to.equal(fundsAmount);
+    });
+
+    it("Should reject FUNDS when native amount does not match bridge amount", async () => {
+      const fundsAmount = 0.5 * LAMPORTS_PER_SOL;
+      const wrongNativeAmount = fundsAmount - 1234;
+      const nativeSolTokenRateLimitPda = getTokenRateLimitPda(
+        PublicKey.default
+      );
+
+      const req = {
+        recipient: Array.from(Buffer.alloc(20, 0)),
+        token: PublicKey.default,
+        amount: new anchor.BN(fundsAmount),
+        payload: Buffer.from([]),
+        revertInstruction: createRevertInstruction(user1.publicKey),
+        signatureData: Buffer.from("invalid_native_amount"),
+      };
+
+      try {
+        await program.methods
+          .sendUniversalTx(req, withProtocolFee(wrongNativeAmount))
+          .accounts({
+            config: configPda,
+            vault: vaultPda,
+            feeVault: feeVaultPda,
+            userTokenAccount: vaultPda,
+            gatewayTokenAccount: vaultPda,
+            user: user1.publicKey,
+            priceUpdate: mockPriceFeed,
+            rateLimitConfig: rateLimitConfigPda,
+            tokenRateLimit: nativeSolTokenRateLimitPda,
+            tokenProgram: spl.TOKEN_PROGRAM_ID,
+            systemProgram: SystemProgram.programId,
+          })
+          .signers([user1])
+          .rpc();
+        expect.fail("Should reject FUNDS when native amount mismatches");
+      } catch (error: any) {
+        expect(error).to.exist;
+        const errorCode =
+          error.error?.errorCode?.code || error.error?.errorCode || error.code;
+        expect(errorCode).to.equal("InvalidAmount");
+      }
+    });
+  });
+
+  describe("FUNDS Route - SPL Token", () => {
+    it("Should bridge SPL token funds", async () => {
+      // Create user token account and mint tokens using mock token's methods
+      const userTokenAccount = await mockUSDT.createTokenAccount(
+        user1.publicKey
+      );
+      const gatewayTokenAccount = await mockUSDT.createTokenAccount(
+        vaultPda,
+        true
+      );
+
+      // Mint tokens using mock token's mintTo method (uses correct mint authority)
+      await mockUSDT.mintTo(userTokenAccount, 1000);
+      const tokenAmount = new anchor.BN(1000 * 10 ** mockUSDT.config.decimals);
+
+      const initialGatewayBalance = await mockUSDT.getBalance(gatewayTokenAccount);
+      const initialFeeVaultBalance = await provider.connection.getBalance(feeVaultPda);
+      const usdtTokenRateLimitPda = getTokenRateLimitPda(
+        mockUSDT.mint.publicKey
+      );
+
+      const req = {
+        recipient: Array.from(Buffer.alloc(20, 0)),
+        token: mockUSDT.mint.publicKey,
+        amount: tokenAmount,
+        payload: Buffer.from([]),
+        revertInstruction: createRevertInstruction(user1.publicKey),
+        signatureData: Buffer.from("spl_funds_sig"),
+      };
+
+      await program.methods
+        .sendUniversalTx(req, withProtocolFee(0)) // Fee-only native amount for SPL FUNDS
+        .accounts({
+          config: configPda,
+          vault: vaultPda,
+          feeVault: feeVaultPda,
+          userTokenAccount: userTokenAccount,
+          gatewayTokenAccount: gatewayTokenAccount,
+          user: user1.publicKey,
+          priceUpdate: mockPriceFeed,
+          rateLimitConfig: rateLimitConfigPda,
+          tokenRateLimit: usdtTokenRateLimitPda,
+          tokenProgram: spl.TOKEN_PROGRAM_ID,
+          systemProgram: SystemProgram.programId,
+        })
+        .signers([user1])
+        .rpc();
+
+      const finalGatewayBalance = await mockUSDT.getBalance(gatewayTokenAccount);
+      const finalFeeVaultBalance = await provider.connection.getBalance(feeVaultPda);
+      const balanceIncrease =
+        (finalGatewayBalance - initialGatewayBalance) * 10 ** mockUSDT.config.decimals;
+      expect(balanceIncrease).to.equal(tokenAmount.toNumber());
+      expect(finalFeeVaultBalance - initialFeeVaultBalance).to.equal(DEFAULT_PROTOCOL_FEE_LAMPORTS);
+    });
+
+    it("Should reject FUNDS SPL when native SOL is provided", async () => {
+      const userTokenAccount = await mockUSDT.createTokenAccount(
+        user1.publicKey
+      );
+      const gatewayTokenAccount = await mockUSDT.createTokenAccount(
+        vaultPda,
+        true
+      );
+
+      await mockUSDT.mintTo(userTokenAccount, 1000);
+      const tokenAmount = new anchor.BN(1000 * 10 ** mockUSDT.config.decimals);
+      const usdtTokenRateLimitPda = getTokenRateLimitPda(
+        mockUSDT.mint.publicKey
+      );
+      const nativeAmount = calculateSolAmount(1.5, solPrice);
+
+      const req = {
+        recipient: Array.from(Buffer.alloc(20, 0)),
+        token: mockUSDT.mint.publicKey,
+        amount: tokenAmount,
+        payload: Buffer.from([]),
+        revertInstruction: createRevertInstruction(user1.publicKey),
+        signatureData: Buffer.from("spl_native_invalid"),
+      };
+
+      try {
+        await program.methods
+          .sendUniversalTx(req, withProtocolFee(nativeAmount))
+          .accounts({
+            config: configPda,
+            vault: vaultPda,
+            feeVault: feeVaultPda,
+            userTokenAccount: userTokenAccount,
+            gatewayTokenAccount: gatewayTokenAccount,
+            user: user1.publicKey,
+            priceUpdate: mockPriceFeed,
+            rateLimitConfig: rateLimitConfigPda,
+            tokenRateLimit: usdtTokenRateLimitPda,
+            tokenProgram: spl.TOKEN_PROGRAM_ID,
+            systemProgram: SystemProgram.programId,
+          })
+          .signers([user1])
+          .rpc();
+        expect.fail("Should reject FUNDS SPL when native SOL is attached");
+      } catch (error: any) {
+        expect(error).to.exist;
+        const errorCode =
+          error.error?.errorCode?.code || error.error?.errorCode || error.code;
+        expect(errorCode).to.equal("InvalidAmount");
+      }
+    });
+  });
+
+  describe("FUNDS_AND_PAYLOAD Route - Native SOL with Batching", () => {
+    it("Should batch gas + funds for native SOL", async () => {
+      // Case 2.2: Batching with native SOL
+      // Split: gasAmount = native_amount - req.amount
+      // Gas must be >= $1 USD (min cap), funds can be any amount
+      // Strategy: Use larger gas amount ($3) and small funds amount to ensure gas >= $1 after split
+      const gasAmountLamports = calculateSolAmount(3.0, solPrice); // $3.00 for gas (well above $1 min cap)
+      const fundsAmountLamports = calculateSolAmount(0.1, solPrice); // $0.10 for funds (very small)
+      const totalAmount = gasAmountLamports + fundsAmountLamports; // Total = gas + funds
+
+      // Verify: after split, gas_amount = totalAmount - fundsAmount = gasAmountLamports (should be >= $1)
+      const expectedGasAfterSplit = totalAmount - fundsAmountLamports;
+      const expectedGasUsd =
+        (expectedGasAfterSplit / LAMPORTS_PER_SOL) * solPrice;
+      if (expectedGasUsd < 1.0) {
+        throw new Error(
+          `Expected gas after split ${expectedGasUsd.toFixed(
+            4
+          )} USD is below minimum $1 USD cap. Gas: ${gasAmountLamports}, Funds: ${fundsAmountLamports}, Total: ${totalAmount}`
         );
-        return pda;
-    };
+      }
 
-    before(async () => {
-        admin = sharedState.getAdmin();
-        tssAddress = sharedState.getTssAddress();
-        pauser = sharedState.getPauser();
-        user1 = Keypair.generate();
-        user2 = Keypair.generate();
+      const initialVaultBalance = await provider.connection.getBalance(
+        vaultPda
+      );
+      const nativeSolTokenRateLimitPda = getTokenRateLimitPda(
+        PublicKey.default
+      );
 
-        const airdropAmount = 20 * LAMPORTS_PER_SOL;
-        await Promise.all([
-            provider.connection.requestAirdrop(user1.publicKey, airdropAmount),
-            provider.connection.requestAirdrop(user2.publicKey, airdropAmount),
-        ]);
-        await new Promise(resolve => setTimeout(resolve, 2000));
+      const req = {
+        recipient: Array.from(Buffer.alloc(20, 1)), // Non-zero allowed for FUNDS_AND_PAYLOAD
+        token: PublicKey.default,
+        amount: new anchor.BN(fundsAmountLamports),
+        payload: serializePayload(createPayload(1)), // Non-empty payload required
+        revertInstruction: createRevertInstruction(user1.publicKey),
+        signatureData: Buffer.from("batched_sig"),
+      };
 
-        [configPda] = PublicKey.findProgramAddressSync([Buffer.from("config")], program.programId);
-        [vaultPda] = PublicKey.findProgramAddressSync([Buffer.from("vault")], program.programId);
-        [rateLimitConfigPda] = PublicKey.findProgramAddressSync([Buffer.from("rate_limit_config")], program.programId);
+      await program.methods
+        .sendUniversalTx(req, withProtocolFee(totalAmount))
+        .accounts({
+          config: configPda,
+          vault: vaultPda,
+          feeVault: feeVaultPda,
+          userTokenAccount: vaultPda, // Dummy account for native SOL routes
+          gatewayTokenAccount: vaultPda, // Dummy account for native SOL routes
+          user: user1.publicKey,
+          priceUpdate: mockPriceFeed,
+          rateLimitConfig: rateLimitConfigPda,
+          tokenRateLimit: nativeSolTokenRateLimitPda,
+          tokenProgram: spl.TOKEN_PROGRAM_ID,
+          systemProgram: SystemProgram.programId,
+        })
+        .signers([user1])
+        .rpc();
 
-        mockPriceFeed = sharedState.getMockPriceFeed();
-        solPrice = await getSolPrice(mockPriceFeed);
-
-        // Get mock tokens
-        mockUSDT = sharedState.getMockUSDT();
-        mockUSDC = sharedState.getMockUSDC();
-
-        // Initialize token rate limit accounts (required for universal gateway)
-        // Use a very large threshold to effectively disable rate limits (since admin function requires > 0)
-        // The rate limit will be effectively disabled because epoch_duration is 0 by default
-        const veryLargeThreshold = new anchor.BN("1000000000000000000000"); // 1 sextillion (effectively unlimited)
-
-        // Initialize native SOL rate limit
-        const nativeSolTokenRateLimitPda = getTokenRateLimitPda(PublicKey.default);
-        try {
-            await program.account.tokenRateLimit.fetch(nativeSolTokenRateLimitPda);
-        } catch {
-            // Not initialized, create it with very large threshold (effectively disabled)
-            await program.methods
-                .setTokenRateLimit(veryLargeThreshold)
-                .accounts({
-                    admin: admin.publicKey,
-                    config: configPda,
-                    rateLimitConfig: rateLimitConfigPda,
-                    tokenRateLimit: nativeSolTokenRateLimitPda,
-                    tokenMint: PublicKey.default,
-                    systemProgram: SystemProgram.programId,
-                })
-                .signers([admin])
-                .rpc();
-        }
-
-        // Initialize USDT rate limit
-        const usdtTokenRateLimitPda = getTokenRateLimitPda(mockUSDT.mint.publicKey);
-        try {
-            await program.account.tokenRateLimit.fetch(usdtTokenRateLimitPda);
-        } catch {
-            await program.methods
-                .setTokenRateLimit(veryLargeThreshold)
-                .accounts({
-                    admin: admin.publicKey,
-                    config: configPda,
-                    rateLimitConfig: rateLimitConfigPda,
-                    tokenRateLimit: usdtTokenRateLimitPda,
-                    tokenMint: mockUSDT.mint.publicKey,
-                    systemProgram: SystemProgram.programId,
-                })
-                .signers([admin])
-                .rpc();
-        }
-
-        // Initialize USDC rate limit
-        const usdcTokenRateLimitPda = getTokenRateLimitPda(mockUSDC.mint.publicKey);
-        try {
-            await program.account.tokenRateLimit.fetch(usdcTokenRateLimitPda);
-        } catch {
-            await program.methods
-                .setTokenRateLimit(veryLargeThreshold)
-                .accounts({
-                    admin: admin.publicKey,
-                    config: configPda,
-                    rateLimitConfig: rateLimitConfigPda,
-                    tokenRateLimit: usdcTokenRateLimitPda,
-                    tokenMint: mockUSDC.mint.publicKey,
-                    systemProgram: SystemProgram.programId,
-                })
-                .signers([admin])
-                .rpc();
-        }
+      const finalVaultBalance = await provider.connection.getBalance(vaultPda);
+      // Bridge vault receives gas + funds; fee goes to fee_vault
+      expect(finalVaultBalance - initialVaultBalance).to.equal(totalAmount);
     });
 
-    describe("GAS Route (TxType.GAS)", () => {
-        it("Should deposit native SOL as gas without payload", async () => {
-            const gasAmount = calculateSolAmount(2.5, solPrice);
-            const initialVaultBalance = await provider.connection.getBalance(vaultPda);
-            const initialUserBalance = await provider.connection.getBalance(user1.publicKey);
+    it("Should reject FUNDS_AND_PAYLOAD native when native amount is insufficient", async () => {
+      const fundsAmount = calculateSolAmount(0.75, solPrice);
+      const insufficientNative = fundsAmount - 50_000; // native < funds
+      const nativeSolTokenRateLimitPda = getTokenRateLimitPda(
+        PublicKey.default
+      );
 
-            const nativeSolTokenRateLimitPda = getTokenRateLimitPda(PublicKey.default);
+      const req = {
+        recipient: Array.from(Buffer.alloc(20, 1)),
+        token: PublicKey.default,
+        amount: new anchor.BN(fundsAmount),
+        payload: serializePayload(createPayload(1)),
+        revertInstruction: createRevertInstruction(user1.publicKey),
+        signatureData: Buffer.from("insufficient_native_sig"),
+      };
 
-            const req = {
-                recipient: Array.from(Buffer.alloc(20, 0)),
-                token: PublicKey.default,
-                amount: new anchor.BN(0),
-                payload: Buffer.from([]),
-                revertInstruction: createRevertInstruction(user1.publicKey),
-                signatureData: Buffer.from("gas_sig"),
-            };
+      try {
+        await program.methods
+          .sendUniversalTx(req, withProtocolFee(insufficientNative))
+          .accounts({
+            config: configPda,
+            vault: vaultPda,
+            feeVault: feeVaultPda,
+            userTokenAccount: vaultPda,
+            gatewayTokenAccount: vaultPda,
+            user: user1.publicKey,
+            priceUpdate: mockPriceFeed,
+            rateLimitConfig: rateLimitConfigPda,
+            tokenRateLimit: nativeSolTokenRateLimitPda,
+            tokenProgram: spl.TOKEN_PROGRAM_ID,
+            systemProgram: SystemProgram.programId,
+          })
+          .signers([user1])
+          .rpc();
+        expect.fail("Should reject when native gas is below bridge amount");
+      } catch (error: any) {
+        expect(error).to.exist;
+        const errorCode =
+          error.error?.errorCode?.code || error.error?.errorCode || error.code;
+        expect(errorCode).to.equal("InvalidAmount");
+      }
+    });
+  });
 
-            await program.methods
-                .sendUniversalTx(req, new anchor.BN(gasAmount))
-                .accounts({
-                    config: configPda,
-                    vault: vaultPda,
-                    userTokenAccount: vaultPda, // Dummy account for native SOL routes
-                    gatewayTokenAccount: vaultPda, // Dummy account for native SOL routes
-                    user: user1.publicKey,
-                    priceUpdate: mockPriceFeed,
-                    rateLimitConfig: rateLimitConfigPda,
-                    tokenRateLimit: nativeSolTokenRateLimitPda,
-                    tokenProgram: spl.TOKEN_PROGRAM_ID,
-                    systemProgram: SystemProgram.programId,
-                })
-                .signers([user1])
-                .rpc();
+  describe("FUNDS_AND_PAYLOAD Route - SPL Token", () => {
+    it("Should bridge SPL funds with payload without batching (Case 2.1)", async () => {
+      // Case 2.1: No Batching (native_amount == 0): user already has UEA with gas on Push Chain
+      // User can directly move req.amount for req.token to Push Chain (SPL token only for Case 2.1)
+      // Use USDC to avoid rate limit conflicts with USDT used in previous tests
+      const userTokenAccount = await mockUSDC.createTokenAccount(
+        user1.publicKey
+      );
+      const gatewayTokenAccount = await mockUSDC.createTokenAccount(
+        vaultPda,
+        true
+      );
 
-            const finalVaultBalance = await provider.connection.getBalance(vaultPda);
-            expect(finalVaultBalance - initialVaultBalance).to.equal(gasAmount);
-        });
+      // Mint tokens using mock token's mintTo method
+      await mockUSDC.mintTo(userTokenAccount, 500);
+      const tokenAmount = new anchor.BN(500 * 10 ** mockUSDC.config.decimals);
 
-        it("Should route GAS request with payload to GAS_AND_PAYLOAD (not reject)", async () => {
-            // NOTE: This test verifies the correct behavior - amount==0 + payload>0 routes to GAS_AND_PAYLOAD
-            // The payload validation is commented out in send_tx_with_gas_route (matching EVM V0)
-            const gasAmount = calculateSolAmount(2.5, solPrice);
-            const nativeSolTokenRateLimitPda = getTokenRateLimitPda(PublicKey.default);
-            const initialVaultBalance = await provider.connection.getBalance(vaultPda);
+      const initialGatewayBalance = await mockUSDC.getBalance(gatewayTokenAccount);
+      const initialVaultBalance = await provider.connection.getBalance(vaultPda);
+      const initialFeeVaultBalance = await provider.connection.getBalance(feeVaultPda);
+      const usdcTokenRateLimitPda = getTokenRateLimitPda(
+        mockUSDC.mint.publicKey
+      );
 
-            const req = {
-                recipient: Array.from(Buffer.alloc(20, 0)),
-                token: PublicKey.default,
-                amount: new anchor.BN(0),
-                payload: serializePayload(createPayload(99)), // Non-empty payload
-                revertInstruction: createRevertInstruction(user1.publicKey),
-                signatureData: Buffer.from("sig"),
-            };
+      const req = {
+        recipient: Array.from(Buffer.alloc(20, 1)), // Non-zero allowed for FUNDS_AND_PAYLOAD
+        token: mockUSDC.mint.publicKey,
+        amount: tokenAmount,
+        payload: serializePayload(createPayload(1)), // Must have payload for FUNDS_AND_PAYLOAD
+        revertInstruction: createRevertInstruction(user1.publicKey),
+        signatureData: Buffer.from("spl_no_batch_sig"),
+      };
 
-            // Should succeed and route to GAS_AND_PAYLOAD (fetchTxType logic)
-            await program.methods
-                .sendUniversalTx(req, new anchor.BN(gasAmount))
-                .accounts({
-                    config: configPda,
-                    vault: vaultPda,
-                    userTokenAccount: vaultPda, // Correct: use vaultPda as dummy for native SOL
-                    gatewayTokenAccount: vaultPda, // Correct: use vaultPda as dummy for native SOL
-                    user: user1.publicKey,
-                    priceUpdate: mockPriceFeed,
-                    rateLimitConfig: rateLimitConfigPda,
-                    tokenRateLimit: nativeSolTokenRateLimitPda,
-                    tokenProgram: spl.TOKEN_PROGRAM_ID,
-                    systemProgram: SystemProgram.programId,
-                })
-                .signers([user1])
-                .rpc();
+      // With protocol fee enabled, this route sends only fee as native amount.
+      await program.methods
+        .sendUniversalTx(req, withProtocolFee(0))
+        .accounts({
+          config: configPda,
+          vault: vaultPda,
+          feeVault: feeVaultPda,
+          userTokenAccount: userTokenAccount,
+          gatewayTokenAccount: gatewayTokenAccount,
+          user: user1.publicKey,
+          priceUpdate: mockPriceFeed,
+          rateLimitConfig: rateLimitConfigPda,
+          tokenRateLimit: usdcTokenRateLimitPda,
+          tokenProgram: spl.TOKEN_PROGRAM_ID,
+          systemProgram: SystemProgram.programId,
+        })
+        .signers([user1])
+        .rpc();
 
-            // Verify transaction succeeded (vault balance increased)
-            const finalVaultBalance = await provider.connection.getBalance(vaultPda);
-            expect(finalVaultBalance - initialVaultBalance).to.equal(gasAmount);
-        });
+      // SPL tokens go to gateway token account; fee goes to fee_vault; bridge vault unchanged
+      const finalGatewayBalance = await mockUSDC.getBalance(gatewayTokenAccount);
+      const finalVaultBalance = await provider.connection.getBalance(vaultPda);
+      const finalFeeVaultBalance = await provider.connection.getBalance(feeVaultPda);
+      const balanceIncrease =
+        (finalGatewayBalance - initialGatewayBalance) * 10 ** mockUSDC.config.decimals;
+      expect(balanceIncrease).to.equal(tokenAmount.toNumber());
+      expect(finalVaultBalance - initialVaultBalance).to.equal(0);
+      expect(finalFeeVaultBalance - initialFeeVaultBalance).to.equal(DEFAULT_PROTOCOL_FEE_LAMPORTS);
     });
 
-    describe("GAS_AND_PAYLOAD Route", () => {
-        it("Should deposit gas with payload", async () => {
-            const gasAmount = calculateSolAmount(2.5, solPrice);
-            const initialVaultBalance = await provider.connection.getBalance(vaultPda);
-            const nativeSolTokenRateLimitPda = getTokenRateLimitPda(PublicKey.default);
+    it("Should batch native gas + SPL funds (Case 2.3)", async () => {
+      // Setup SPL token accounts using mock token's methods
+      const userTokenAccount = await mockUSDC.createTokenAccount(
+        user1.publicKey
+      );
+      const gatewayTokenAccount = await mockUSDC.createTokenAccount(
+        vaultPda,
+        true
+      );
 
-            const req = {
-                recipient: Array.from(Buffer.alloc(20, 0)),
-                token: PublicKey.default,
-                amount: new anchor.BN(0),
-                payload: serializePayload(createPayload(1)),
-                revertInstruction: createRevertInstruction(user1.publicKey),
-                signatureData: Buffer.from("gas_payload_sig"),
-            };
+      // Mint tokens using mock token's mintTo method
+      await mockUSDC.mintTo(userTokenAccount, 500);
+      const tokenAmount = new anchor.BN(500 * 10 ** mockUSDC.config.decimals);
 
-            await program.methods
-                .sendUniversalTx(req, new anchor.BN(gasAmount))
-                .accounts({
-                    config: configPda,
-                    vault: vaultPda,
-                    userTokenAccount: vaultPda, // Dummy account for native SOL routes
-                    gatewayTokenAccount: vaultPda, // Dummy account for native SOL routes
-                    user: user1.publicKey,
-                    priceUpdate: mockPriceFeed,
-                    rateLimitConfig: rateLimitConfigPda,
-                    tokenRateLimit: nativeSolTokenRateLimitPda,
-                    tokenProgram: spl.TOKEN_PROGRAM_ID,
-                    systemProgram: SystemProgram.programId,
-                })
-                .signers([user1])
-                .rpc();
+      // Case 2.3: Batching with SPL + native gas
+      // Gas amount must be >= $1 USD (min cap) and <= $10 USD (max cap)
+      // native_amount is sent as gas, req.amount is SPL bridge amount
+      const gasAmount = calculateSolAmount(2.5, solPrice); // $2.50 for gas (within $1-$10 cap)
 
-            const finalVaultBalance = await provider.connection.getBalance(vaultPda);
-            expect(finalVaultBalance - initialVaultBalance).to.equal(gasAmount);
-        });
+      // Verify gas amount is >= $1 USD
+      const gasUsd = (gasAmount / LAMPORTS_PER_SOL) * solPrice;
+      if (gasUsd < 1.0) {
+        throw new Error(`Gas amount ${gasUsd} USD is below minimum $1 USD cap`);
+      }
+      const initialVaultBalance = await provider.connection.getBalance(
+        vaultPda
+      );
+      const initialGatewayBalance = await mockUSDC.getBalance(
+        gatewayTokenAccount
+      );
+      const usdcTokenRateLimitPda = getTokenRateLimitPda(
+        mockUSDC.mint.publicKey
+      );
 
-        it("Should allow payload-only execution (gas_amount == 0)", async () => {
-            const nativeSolTokenRateLimitPda = getTokenRateLimitPda(PublicKey.default);
+      const req = {
+        recipient: Array.from(Buffer.alloc(20, 1)),
+        token: mockUSDC.mint.publicKey,
+        amount: tokenAmount,
+        payload: serializePayload(createPayload(1)), // Non-empty payload required
+        revertInstruction: createRevertInstruction(user1.publicKey),
+        signatureData: Buffer.from("spl_batched_sig"),
+      };
 
-            const req = {
-                recipient: Array.from(Buffer.alloc(20, 0)),
-                token: PublicKey.default,
-                amount: new anchor.BN(0),
-                payload: serializePayload(createPayload(1)),
-                revertInstruction: createRevertInstruction(user1.publicKey),
-                signatureData: Buffer.from("payload_only"),
-            };
+      const initialFeeVaultBalance = await provider.connection.getBalance(feeVaultPda);
 
-            // Should succeed with 0 native amount
-            await program.methods
-                .sendUniversalTx(req, new anchor.BN(0))
-                .accounts({
-                    config: configPda,
-                    vault: vaultPda,
-                    userTokenAccount: vaultPda, // Dummy account for native SOL routes
-                    gatewayTokenAccount: vaultPda, // Dummy account for native SOL routes
-                    user: user1.publicKey,
-                    priceUpdate: mockPriceFeed,
-                    rateLimitConfig: rateLimitConfigPda,
-                    tokenRateLimit: nativeSolTokenRateLimitPda,
-                    tokenProgram: spl.TOKEN_PROGRAM_ID,
-                    systemProgram: SystemProgram.programId,
-                })
-                .signers([user1])
-                .rpc();
-        });
+      await program.methods
+        .sendUniversalTx(req, withProtocolFee(gasAmount))
+        .accounts({
+          config: configPda,
+          vault: vaultPda,
+          feeVault: feeVaultPda,
+          userTokenAccount: userTokenAccount,
+          gatewayTokenAccount: gatewayTokenAccount,
+          user: user1.publicKey,
+          priceUpdate: mockPriceFeed,
+          rateLimitConfig: rateLimitConfigPda,
+          tokenRateLimit: usdcTokenRateLimitPda,
+          tokenProgram: spl.TOKEN_PROGRAM_ID,
+          systemProgram: SystemProgram.programId,
+        })
+        .signers([user1])
+        .rpc();
+
+      const finalVaultBalance = await provider.connection.getBalance(vaultPda);
+      const finalFeeVaultBalance = await provider.connection.getBalance(feeVaultPda);
+      // Bridge vault receives only gas (no fee); fee goes to fee_vault
+      expect(finalVaultBalance - initialVaultBalance).to.equal(gasAmount);
+      expect(finalFeeVaultBalance - initialFeeVaultBalance).to.equal(DEFAULT_PROTOCOL_FEE_LAMPORTS);
+
+      const finalGatewayBalance = await mockUSDC.getBalance(
+        gatewayTokenAccount
+      );
+      const balanceIncrease =
+        (finalGatewayBalance - initialGatewayBalance) *
+        10 ** mockUSDC.config.decimals;
+      expect(balanceIncrease).to.equal(tokenAmount.toNumber());
     });
 
-    describe("FUNDS Route - Native SOL", () => {
-        it("Should bridge native SOL funds", async () => {
-            const fundsAmount = 0.5 * LAMPORTS_PER_SOL;
-            const initialVaultBalance = await provider.connection.getBalance(vaultPda);
-            const nativeSolTokenRateLimitPda = getTokenRateLimitPda(PublicKey.default);
+    it("Should reject FUNDS_AND_PAYLOAD SPL when token rate limit PDA mismatches", async () => {
+      const userTokenAccount = await mockUSDC.createTokenAccount(
+        user1.publicKey
+      );
+      const gatewayTokenAccount = await mockUSDC.createTokenAccount(
+        vaultPda,
+        true
+      );
 
-            const req = {
-                recipient: Array.from(Buffer.alloc(20, 0)), // Must be zero for FUNDS
-                token: PublicKey.default,
-                amount: new anchor.BN(fundsAmount),
-                payload: Buffer.from([]),
-                revertInstruction: createRevertInstruction(user1.publicKey),
-                signatureData: Buffer.from("funds_sig"),
-            };
+      await mockUSDC.mintTo(userTokenAccount, 500);
+      const tokenAmount = new anchor.BN(500 * 10 ** mockUSDC.config.decimals);
+      const nativeSolTokenRateLimitPda = getTokenRateLimitPda(
+        PublicKey.default
+      ); // intentionally wrong
 
-            await program.methods
-                .sendUniversalTx(req, new anchor.BN(fundsAmount))
-                .accounts({
-                    config: configPda,
-                    vault: vaultPda,
-                    userTokenAccount: vaultPda, // Dummy account for native SOL routes
-                    gatewayTokenAccount: vaultPda, // Dummy account for native SOL routes
-                    user: user1.publicKey,
-                    priceUpdate: mockPriceFeed,
-                    rateLimitConfig: rateLimitConfigPda,
-                    tokenRateLimit: nativeSolTokenRateLimitPda,
-                    tokenProgram: spl.TOKEN_PROGRAM_ID,
-                    systemProgram: SystemProgram.programId,
-                })
-                .signers([user1])
-                .rpc();
+      const req = {
+        recipient: Array.from(Buffer.alloc(20, 1)),
+        token: mockUSDC.mint.publicKey,
+        amount: tokenAmount,
+        payload: serializePayload(createPayload(1)),
+        revertInstruction: createRevertInstruction(user1.publicKey),
+        signatureData: Buffer.from("spl_bad_rate_limit"),
+      };
 
-            const finalVaultBalance = await provider.connection.getBalance(vaultPda);
-            expect(finalVaultBalance - initialVaultBalance).to.equal(fundsAmount);
-        });
+      try {
+        await program.methods
+          .sendUniversalTx(req, withProtocolFee(0))
+          .accounts({
+            config: configPda,
+            vault: vaultPda,
+            feeVault: feeVaultPda,
+            userTokenAccount: userTokenAccount,
+            gatewayTokenAccount: gatewayTokenAccount,
+            user: user1.publicKey,
+            priceUpdate: mockPriceFeed,
+            rateLimitConfig: rateLimitConfigPda,
+            tokenRateLimit: nativeSolTokenRateLimitPda,
+            tokenProgram: spl.TOKEN_PROGRAM_ID,
+            systemProgram: SystemProgram.programId,
+          })
+          .signers([user1])
+          .rpc();
+        expect.fail(
+          "Should reject FUNDS_AND_PAYLOAD SPL when token rate limit PDA is invalid"
+        );
+      } catch (error: any) {
+        expect(error).to.exist;
+        const errorCode =
+          error.error?.errorCode?.code || error.error?.errorCode || error.code;
+        expect(errorCode).to.equal("InvalidToken");
+      }
+    });
+  });
 
-        it("Should bridge native SOL funds to explicit recipient", async () => {
-            const fundsAmount = 0.75 * LAMPORTS_PER_SOL;
-            const initialVaultBalance = await provider.connection.getBalance(vaultPda);
-            const nativeSolTokenRateLimitPda = getTokenRateLimitPda(PublicKey.default);
+  describe("Error Cases", () => {
+    it("Should reject when paused", async () => {
+      await program.methods
+        .pause()
+        .accounts({ pauser: pauser.publicKey, config: configPda })
+        .signers([pauser])
+        .rpc();
 
-            const req = {
-                recipient: Array.from(Buffer.alloc(20, 1)), // Non-zero recipient now allowed
-                token: PublicKey.default,
-                amount: new anchor.BN(fundsAmount),
-                payload: Buffer.from([]),
-                revertInstruction: createRevertInstruction(user1.publicKey),
-                signatureData: Buffer.from("funds_nonzero_recipient"),
-            };
+      const gasAmount = calculateSolAmount(2.5, solPrice);
+      const nativeSolTokenRateLimitPda = getTokenRateLimitPda(
+        PublicKey.default
+      );
 
-            await program.methods
-                .sendUniversalTx(req, new anchor.BN(fundsAmount))
-                .accounts({
-                    config: configPda,
-                    vault: vaultPda,
-                    userTokenAccount: vaultPda,
-                    gatewayTokenAccount: vaultPda,
-                    user: user1.publicKey,
-                    priceUpdate: mockPriceFeed,
-                    rateLimitConfig: rateLimitConfigPda,
-                    tokenRateLimit: nativeSolTokenRateLimitPda,
-                    tokenProgram: spl.TOKEN_PROGRAM_ID,
-                    systemProgram: SystemProgram.programId,
-                })
-                .signers([user1])
-                .rpc();
+      const req = {
+        recipient: Array.from(Buffer.alloc(20, 0)),
+        token: PublicKey.default,
+        amount: new anchor.BN(0),
+        payload: Buffer.from([]),
+        revertInstruction: createRevertInstruction(user1.publicKey),
+        signatureData: Buffer.from("sig"),
+      };
 
-            const finalVaultBalance = await provider.connection.getBalance(vaultPda);
-            expect(finalVaultBalance - initialVaultBalance).to.equal(fundsAmount);
-        });
+      try {
+        await program.methods
+          .sendUniversalTx(req, new anchor.BN(gasAmount))
+          .accounts({
+            config: configPda,
+            vault: vaultPda,
+            feeVault: feeVaultPda,
+            userTokenAccount: vaultPda, // Dummy account for native SOL routes
+            gatewayTokenAccount: vaultPda, // Dummy account for native SOL routes
+            user: user1.publicKey,
+            priceUpdate: mockPriceFeed,
+            rateLimitConfig: rateLimitConfigPda,
+            tokenRateLimit: nativeSolTokenRateLimitPda,
+            tokenProgram: spl.TOKEN_PROGRAM_ID,
+            systemProgram: SystemProgram.programId,
+          })
+          .signers([user1])
+          .rpc();
+        expect.fail("Should reject when paused");
+      } catch (error: any) {
+        expect(error).to.exist;
+        expect(error.error?.errorCode?.code || error.code).to.equal("Paused");
+      }
 
-        it("Should reject FUNDS when native amount does not match bridge amount", async () => {
-            const fundsAmount = 0.5 * LAMPORTS_PER_SOL;
-            const wrongNativeAmount = fundsAmount - 1234;
-            const nativeSolTokenRateLimitPda = getTokenRateLimitPda(PublicKey.default);
-
-            const req = {
-                recipient: Array.from(Buffer.alloc(20, 0)),
-                token: PublicKey.default,
-                amount: new anchor.BN(fundsAmount),
-                payload: Buffer.from([]),
-                revertInstruction: createRevertInstruction(user1.publicKey),
-                signatureData: Buffer.from("invalid_native_amount"),
-            };
-
-            try {
-                await program.methods
-                    .sendUniversalTx(req, new anchor.BN(wrongNativeAmount))
-                    .accounts({
-                        config: configPda,
-                        vault: vaultPda,
-                        userTokenAccount: vaultPda,
-                        gatewayTokenAccount: vaultPda,
-                        user: user1.publicKey,
-                        priceUpdate: mockPriceFeed,
-                        rateLimitConfig: rateLimitConfigPda,
-                        tokenRateLimit: nativeSolTokenRateLimitPda,
-                        tokenProgram: spl.TOKEN_PROGRAM_ID,
-                        systemProgram: SystemProgram.programId,
-                    })
-                    .signers([user1])
-                    .rpc();
-                expect.fail("Should reject FUNDS when native amount mismatches");
-            } catch (error: any) {
-                expect(error).to.exist;
-                const errorCode = error.error?.errorCode?.code || error.error?.errorCode || error.code;
-                expect(errorCode).to.equal("InvalidAmount");
-            }
-        });
+      await program.methods
+        .unpause()
+        .accounts({ pauser: pauser.publicKey, config: configPda })
+        .signers([pauser])
+        .rpc();
     });
 
-    describe("FUNDS Route - SPL Token", () => {
-        it("Should bridge SPL token funds", async () => {
-            // Create user token account and mint tokens using mock token's methods
-            const userTokenAccount = await mockUSDT.createTokenAccount(user1.publicKey);
-            const gatewayTokenAccount = await mockUSDT.createTokenAccount(vaultPda, true);
+    it("Should reject invalid parameter combinations (no gas or funds)", async () => {
+      const nativeSolTokenRateLimitPda = getTokenRateLimitPda(
+        PublicKey.default
+      );
 
-            // Mint tokens using mock token's mintTo method (uses correct mint authority)
-            await mockUSDT.mintTo(userTokenAccount, 1000);
-            const tokenAmount = new anchor.BN(1000 * 10 ** mockUSDT.config.decimals);
+      const req = {
+        recipient: Array.from(Buffer.alloc(20, 0)),
+        token: PublicKey.default,
+        amount: new anchor.BN(0),
+        payload: Buffer.from([]),
+        revertInstruction: createRevertInstruction(user1.publicKey),
+        signatureData: Buffer.from("sig"),
+      };
 
-            const initialGatewayBalance = await mockUSDT.getBalance(gatewayTokenAccount);
-            const usdtTokenRateLimitPda = getTokenRateLimitPda(mockUSDT.mint.publicKey);
+      try {
+        await program.methods
+          .sendUniversalTx(req, withProtocolFee(0))
+          .accounts({
+            config: configPda,
+            vault: vaultPda,
+            feeVault: feeVaultPda,
+            userTokenAccount: vaultPda,
+            gatewayTokenAccount: vaultPda,
+            user: user1.publicKey,
+            priceUpdate: mockPriceFeed,
+            rateLimitConfig: rateLimitConfigPda,
+            tokenRateLimit: nativeSolTokenRateLimitPda,
+            tokenProgram: spl.TOKEN_PROGRAM_ID,
+            systemProgram: SystemProgram.programId,
+          })
+          .signers([user1])
+          .rpc();
+        expect.fail("Should reject parameter set without gas or funds");
+      } catch (error: any) {
+        expect(error).to.exist;
+        const errorCode =
+          error.error?.errorCode?.code || error.error?.errorCode || error.code;
+        expect(errorCode).to.equal("InvalidInput");
+      }
+    });
+  });
 
-            const req = {
-                recipient: Array.from(Buffer.alloc(20, 0)),
-                token: mockUSDT.mint.publicKey,
-                amount: tokenAmount,
-                payload: Buffer.from([]),
-                revertInstruction: createRevertInstruction(user1.publicKey),
-                signatureData: Buffer.from("spl_funds_sig"),
-            };
+  describe("Protocol Fee", () => {
+    it("Should accumulate fee_vault balance across multiple txs", async () => {
+      const nativeSolTokenRateLimitPda = getTokenRateLimitPda(PublicKey.default);
+      const gasAmount = calculateSolAmount(2.5, solPrice);
+      const feeVaultBefore = await provider.connection.getBalance(feeVaultPda);
 
-            await program.methods
-                .sendUniversalTx(req, new anchor.BN(0)) // No native SOL for SPL funds
-                .accounts({
-                    config: configPda,
-                    vault: vaultPda,
-                    userTokenAccount: userTokenAccount,
-                    gatewayTokenAccount: gatewayTokenAccount,
-                    user: user1.publicKey,
-                    priceUpdate: mockPriceFeed,
-                    rateLimitConfig: rateLimitConfigPda,
-                    tokenRateLimit: usdtTokenRateLimitPda,
-                    tokenProgram: spl.TOKEN_PROGRAM_ID,
-                    systemProgram: SystemProgram.programId,
-                })
-                .signers([user1])
-                .rpc();
+      const req = {
+        recipient: Array.from(Buffer.alloc(20, 0)),
+        token: PublicKey.default,
+        amount: new anchor.BN(0),
+        payload: Buffer.from([]),
+        revertInstruction: createRevertInstruction(user1.publicKey),
+        signatureData: Buffer.from("acc_test"),
+      };
 
-            const finalGatewayBalance = await mockUSDT.getBalance(gatewayTokenAccount);
-            const balanceIncrease = (finalGatewayBalance - initialGatewayBalance) * 10 ** mockUSDT.config.decimals;
-            expect(balanceIncrease).to.equal(tokenAmount.toNumber());
-        });
+      const accounts = {
+        config: configPda,
+        vault: vaultPda,
+        feeVault: feeVaultPda,
+        userTokenAccount: vaultPda,
+        gatewayTokenAccount: vaultPda,
+        user: user1.publicKey,
+        priceUpdate: mockPriceFeed,
+        rateLimitConfig: rateLimitConfigPda,
+        tokenRateLimit: nativeSolTokenRateLimitPda,
+        tokenProgram: spl.TOKEN_PROGRAM_ID,
+        systemProgram: SystemProgram.programId,
+      };
 
-        it("Should reject FUNDS SPL when native SOL is provided", async () => {
-            const userTokenAccount = await mockUSDT.createTokenAccount(user1.publicKey);
-            const gatewayTokenAccount = await mockUSDT.createTokenAccount(vaultPda, true);
+      await program.methods
+        .sendUniversalTx(req, withProtocolFee(gasAmount))
+        .accounts(accounts)
+        .signers([user1])
+        .rpc();
+      await program.methods
+        .sendUniversalTx(req, withProtocolFee(gasAmount))
+        .accounts(accounts)
+        .signers([user1])
+        .rpc();
 
-            await mockUSDT.mintTo(userTokenAccount, 1000);
-            const tokenAmount = new anchor.BN(1000 * 10 ** mockUSDT.config.decimals);
-            const usdtTokenRateLimitPda = getTokenRateLimitPda(mockUSDT.mint.publicKey);
-            const nativeAmount = calculateSolAmount(1.5, solPrice);
-
-            const req = {
-                recipient: Array.from(Buffer.alloc(20, 0)),
-                token: mockUSDT.mint.publicKey,
-                amount: tokenAmount,
-                payload: Buffer.from([]),
-                revertInstruction: createRevertInstruction(user1.publicKey),
-                signatureData: Buffer.from("spl_native_invalid"),
-            };
-
-            try {
-                await program.methods
-                    .sendUniversalTx(req, new anchor.BN(nativeAmount))
-                    .accounts({
-                        config: configPda,
-                        vault: vaultPda,
-                        userTokenAccount: userTokenAccount,
-                        gatewayTokenAccount: gatewayTokenAccount,
-                        user: user1.publicKey,
-                        priceUpdate: mockPriceFeed,
-                        rateLimitConfig: rateLimitConfigPda,
-                        tokenRateLimit: usdtTokenRateLimitPda,
-                        tokenProgram: spl.TOKEN_PROGRAM_ID,
-                        systemProgram: SystemProgram.programId,
-                    })
-                    .signers([user1])
-                    .rpc();
-                expect.fail("Should reject FUNDS SPL when native SOL is attached");
-            } catch (error: any) {
-                expect(error).to.exist;
-                const errorCode = error.error?.errorCode?.code || error.error?.errorCode || error.code;
-                expect(errorCode).to.equal("InvalidAmount");
-            }
-        });
+      const feeVaultAfter = await provider.connection.getBalance(feeVaultPda);
+      expect(feeVaultAfter - feeVaultBefore).to.equal(2 * DEFAULT_PROTOCOL_FEE_LAMPORTS);
     });
 
-    describe("FUNDS_AND_PAYLOAD Route - Native SOL with Batching", () => {
-        it("Should batch gas + funds for native SOL", async () => {
-            // Case 2.2: Batching with native SOL
-            // Split: gasAmount = native_amount - req.amount
-            // Gas must be >= $1 USD (min cap), funds can be any amount
-            // Strategy: Use larger gas amount ($3) and small funds amount to ensure gas >= $1 after split
-            const gasAmountLamports = calculateSolAmount(3.0, solPrice); // $3.00 for gas (well above $1 min cap)
-            const fundsAmountLamports = calculateSolAmount(0.1, solPrice); // $0.10 for funds (very small)
-            const totalAmount = gasAmountLamports + fundsAmountLamports; // Total = gas + funds
-
-            // Verify: after split, gas_amount = totalAmount - fundsAmount = gasAmountLamports (should be >= $1)
-            const expectedGasAfterSplit = totalAmount - fundsAmountLamports;
-            const expectedGasUsd = (expectedGasAfterSplit / LAMPORTS_PER_SOL) * solPrice;
-            if (expectedGasUsd < 1.0) {
-                throw new Error(`Expected gas after split ${expectedGasUsd.toFixed(4)} USD is below minimum $1 USD cap. Gas: ${gasAmountLamports}, Funds: ${fundsAmountLamports}, Total: ${totalAmount}`);
-            }
-
-            const initialVaultBalance = await provider.connection.getBalance(vaultPda);
-            const nativeSolTokenRateLimitPda = getTokenRateLimitPda(PublicKey.default);
-
-            const req = {
-                recipient: Array.from(Buffer.alloc(20, 1)), // Non-zero allowed for FUNDS_AND_PAYLOAD
-                token: PublicKey.default,
-                amount: new anchor.BN(fundsAmountLamports),
-                payload: serializePayload(createPayload(1)), // Non-empty payload required
-                revertInstruction: createRevertInstruction(user1.publicKey),
-                signatureData: Buffer.from("batched_sig"),
-            };
-
-            await program.methods
-                .sendUniversalTx(req, new anchor.BN(totalAmount))
-                .accounts({
-                    config: configPda,
-                    vault: vaultPda,
-                    userTokenAccount: vaultPda, // Dummy account for native SOL routes
-                    gatewayTokenAccount: vaultPda, // Dummy account for native SOL routes
-                    user: user1.publicKey,
-                    priceUpdate: mockPriceFeed,
-                    rateLimitConfig: rateLimitConfigPda,
-                    tokenRateLimit: nativeSolTokenRateLimitPda,
-                    tokenProgram: spl.TOKEN_PROGRAM_ID,
-                    systemProgram: SystemProgram.programId,
-                })
-                .signers([user1])
-                .rpc();
-
-            const finalVaultBalance = await provider.connection.getBalance(vaultPda);
-            // Should receive both gas and funds
-            expect(finalVaultBalance - initialVaultBalance).to.equal(totalAmount);
-        });
-
-        it("Should reject FUNDS_AND_PAYLOAD native when native amount is insufficient", async () => {
-            const fundsAmount = calculateSolAmount(0.75, solPrice);
-            const insufficientNative = fundsAmount - 50_000; // native < funds
-            const nativeSolTokenRateLimitPda = getTokenRateLimitPda(PublicKey.default);
-
-            const req = {
-                recipient: Array.from(Buffer.alloc(20, 1)),
-                token: PublicKey.default,
-                amount: new anchor.BN(fundsAmount),
-                payload: serializePayload(createPayload(1)),
-                revertInstruction: createRevertInstruction(user1.publicKey),
-                signatureData: Buffer.from("insufficient_native_sig"),
-            };
-
-            try {
-                await program.methods
-                    .sendUniversalTx(req, new anchor.BN(insufficientNative))
-                    .accounts({
-                        config: configPda,
-                        vault: vaultPda,
-                        userTokenAccount: vaultPda,
-                        gatewayTokenAccount: vaultPda,
-                        user: user1.publicKey,
-                        priceUpdate: mockPriceFeed,
-                        rateLimitConfig: rateLimitConfigPda,
-                        tokenRateLimit: nativeSolTokenRateLimitPda,
-                        tokenProgram: spl.TOKEN_PROGRAM_ID,
-                        systemProgram: SystemProgram.programId,
-                    })
-                    .signers([user1])
-                    .rpc();
-                expect.fail("Should reject when native gas is below bridge amount");
-            } catch (error: any) {
-                expect(error).to.exist;
-                const errorCode = error.error?.errorCode?.code || error.error?.errorCode || error.code;
-                expect(errorCode).to.equal("InvalidAmount");
-            }
-        });
+    it("Should reject unauthorized setProtocolFee", async () => {
+      try {
+        await program.methods
+          .setProtocolFee(new anchor.BN(123_456))
+          .accounts({
+            config: configPda,
+            feeVault: feeVaultPda,
+            admin: user1.publicKey,
+            systemProgram: SystemProgram.programId,
+          })
+          .signers([user1])
+          .rpc();
+        expect.fail("Unauthorized setProtocolFee should have failed");
+      } catch (error: any) {
+        expect(error).to.exist;
+        const errorCode =
+          error.error?.errorCode?.code || error.error?.errorCode || error.code;
+        expect(errorCode).to.equal("Unauthorized");
+      }
     });
 
-    describe("FUNDS_AND_PAYLOAD Route - SPL Token", () => {
-        it("Should bridge SPL funds with payload without batching (Case 2.1)", async () => {
-            // Case 2.1: No Batching (native_amount == 0): user already has UEA with gas on Push Chain
-            // User can directly move req.amount for req.token to Push Chain (SPL token only for Case 2.1)
-            // Use USDC to avoid rate limit conflicts with USDT used in previous tests
-            const userTokenAccount = await mockUSDC.createTokenAccount(user1.publicKey);
-            const gatewayTokenAccount = await mockUSDC.createTokenAccount(vaultPda, true);
+    it("Should reject when native amount is below protocol fee", async () => {
+      const nativeSolTokenRateLimitPda = getTokenRateLimitPda(PublicKey.default);
+      const req = {
+        recipient: Array.from(Buffer.alloc(20, 0)),
+        token: PublicKey.default,
+        amount: new anchor.BN(0),
+        payload: Buffer.from([]),
+        revertInstruction: createRevertInstruction(user1.publicKey),
+        signatureData: Buffer.from("insufficient_protocol_fee"),
+      };
 
-            // Mint tokens using mock token's mintTo method
-            await mockUSDC.mintTo(userTokenAccount, 500);
-            const tokenAmount = new anchor.BN(500 * 10 ** mockUSDC.config.decimals);
-
-            const initialGatewayBalance = await mockUSDC.getBalance(gatewayTokenAccount);
-            const usdcTokenRateLimitPda = getTokenRateLimitPda(mockUSDC.mint.publicKey);
-
-            const req = {
-                recipient: Array.from(Buffer.alloc(20, 1)), // Non-zero allowed for FUNDS_AND_PAYLOAD
-                token: mockUSDC.mint.publicKey,
-                amount: tokenAmount,
-                payload: serializePayload(createPayload(1)), // Must have payload for FUNDS_AND_PAYLOAD
-                revertInstruction: createRevertInstruction(user1.publicKey),
-                signatureData: Buffer.from("spl_no_batch_sig"),
-            };
-
-            // native_amount == 0: user already has UEA with gas
-            await program.methods
-                .sendUniversalTx(req, new anchor.BN(0))
-                .accounts({
-                    config: configPda,
-                    vault: vaultPda,
-                    userTokenAccount: userTokenAccount,
-                    gatewayTokenAccount: gatewayTokenAccount,
-                    user: user1.publicKey,
-                    priceUpdate: mockPriceFeed,
-                    rateLimitConfig: rateLimitConfigPda,
-                    tokenRateLimit: usdcTokenRateLimitPda,
-                    tokenProgram: spl.TOKEN_PROGRAM_ID,
-                    systemProgram: SystemProgram.programId,
-                })
-                .signers([user1])
-                .rpc();
-
-            // Should only receive SPL tokens, no native SOL
-            const finalGatewayBalance = await mockUSDC.getBalance(gatewayTokenAccount);
-            const balanceIncrease = (finalGatewayBalance - initialGatewayBalance) * 10 ** mockUSDC.config.decimals;
-            expect(balanceIncrease).to.equal(tokenAmount.toNumber());
-        });
-
-        it("Should batch native gas + SPL funds (Case 2.3)", async () => {
-            // Setup SPL token accounts using mock token's methods
-            const userTokenAccount = await mockUSDC.createTokenAccount(user1.publicKey);
-            const gatewayTokenAccount = await mockUSDC.createTokenAccount(vaultPda, true);
-
-            // Mint tokens using mock token's mintTo method
-            await mockUSDC.mintTo(userTokenAccount, 500);
-            const tokenAmount = new anchor.BN(500 * 10 ** mockUSDC.config.decimals);
-
-            // Case 2.3: Batching with SPL + native gas
-            // Gas amount must be >= $1 USD (min cap) and <= $10 USD (max cap)
-            // native_amount is sent as gas, req.amount is SPL bridge amount
-            const gasAmount = calculateSolAmount(2.5, solPrice); // $2.50 for gas (within $1-$10 cap)
-
-            // Verify gas amount is >= $1 USD
-            const gasUsd = (gasAmount / LAMPORTS_PER_SOL) * solPrice;
-            if (gasUsd < 1.0) {
-                throw new Error(`Gas amount ${gasUsd} USD is below minimum $1 USD cap`);
-            }
-            const initialVaultBalance = await provider.connection.getBalance(vaultPda);
-            const initialGatewayBalance = await mockUSDC.getBalance(gatewayTokenAccount);
-            const usdcTokenRateLimitPda = getTokenRateLimitPda(mockUSDC.mint.publicKey);
-
-            const req = {
-                recipient: Array.from(Buffer.alloc(20, 1)),
-                token: mockUSDC.mint.publicKey,
-                amount: tokenAmount,
-                payload: serializePayload(createPayload(1)), // Non-empty payload required
-                revertInstruction: createRevertInstruction(user1.publicKey),
-                signatureData: Buffer.from("spl_batched_sig"),
-            };
-
-            await program.methods
-                .sendUniversalTx(req, new anchor.BN(gasAmount))
-                .accounts({
-                    config: configPda,
-                    vault: vaultPda,
-                    userTokenAccount: userTokenAccount,
-                    gatewayTokenAccount: gatewayTokenAccount,
-                    user: user1.publicKey,
-                    priceUpdate: mockPriceFeed,
-                    rateLimitConfig: rateLimitConfigPda,
-                    tokenRateLimit: usdcTokenRateLimitPda,
-                    tokenProgram: spl.TOKEN_PROGRAM_ID,
-                    systemProgram: SystemProgram.programId,
-                })
-                .signers([user1])
-                .rpc();
-
-            const finalVaultBalance = await provider.connection.getBalance(vaultPda);
-            expect(finalVaultBalance - initialVaultBalance).to.equal(gasAmount);
-
-            const finalGatewayBalance = await mockUSDC.getBalance(gatewayTokenAccount);
-            const balanceIncrease = (finalGatewayBalance - initialGatewayBalance) * 10 ** mockUSDC.config.decimals;
-            expect(balanceIncrease).to.equal(tokenAmount.toNumber());
-        });
-
-        it("Should reject FUNDS_AND_PAYLOAD SPL when token rate limit PDA mismatches", async () => {
-            const userTokenAccount = await mockUSDC.createTokenAccount(user1.publicKey);
-            const gatewayTokenAccount = await mockUSDC.createTokenAccount(vaultPda, true);
-
-            await mockUSDC.mintTo(userTokenAccount, 500);
-            const tokenAmount = new anchor.BN(500 * 10 ** mockUSDC.config.decimals);
-            const nativeSolTokenRateLimitPda = getTokenRateLimitPda(PublicKey.default); // intentionally wrong
-
-            const req = {
-                recipient: Array.from(Buffer.alloc(20, 1)),
-                token: mockUSDC.mint.publicKey,
-                amount: tokenAmount,
-                payload: serializePayload(createPayload(1)),
-                revertInstruction: createRevertInstruction(user1.publicKey),
-                signatureData: Buffer.from("spl_bad_rate_limit"),
-            };
-
-            try {
-                await program.methods
-                    .sendUniversalTx(req, new anchor.BN(0))
-                    .accounts({
-                        config: configPda,
-                        vault: vaultPda,
-                        userTokenAccount: userTokenAccount,
-                        gatewayTokenAccount: gatewayTokenAccount,
-                        user: user1.publicKey,
-                        priceUpdate: mockPriceFeed,
-                        rateLimitConfig: rateLimitConfigPda,
-                        tokenRateLimit: nativeSolTokenRateLimitPda,
-                        tokenProgram: spl.TOKEN_PROGRAM_ID,
-                        systemProgram: SystemProgram.programId,
-                    })
-                    .signers([user1])
-                    .rpc();
-                expect.fail("Should reject FUNDS_AND_PAYLOAD SPL when token rate limit PDA is invalid");
-            } catch (error: any) {
-                expect(error).to.exist;
-                const errorCode = error.error?.errorCode?.code || error.error?.errorCode || error.code;
-                expect(errorCode).to.equal("InvalidToken");
-            }
-        });
+      try {
+        await program.methods
+          .sendUniversalTx(req, new anchor.BN(DEFAULT_PROTOCOL_FEE_LAMPORTS - 1))
+          .accounts({
+            config: configPda,
+            vault: vaultPda,
+            feeVault: feeVaultPda,
+            userTokenAccount: vaultPda,
+            gatewayTokenAccount: vaultPda,
+            user: user1.publicKey,
+            priceUpdate: mockPriceFeed,
+            rateLimitConfig: rateLimitConfigPda,
+            tokenRateLimit: nativeSolTokenRateLimitPda,
+            tokenProgram: spl.TOKEN_PROGRAM_ID,
+            systemProgram: SystemProgram.programId,
+          })
+          .signers([user1])
+          .rpc();
+        expect.fail("Should reject when native amount is below protocol fee");
+      } catch (error: any) {
+        expect(error).to.exist;
+        const errorCode =
+          error.error?.errorCode?.code || error.error?.errorCode || error.code;
+        expect(errorCode).to.equal("InsufficientProtocolFee");
+      }
     });
 
-    describe("Error Cases", () => {
-        it("Should reject when paused", async () => {
-            await program.methods
-                .pause()
-                .accounts({ pauser: pauser.publicKey, config: configPda })
-                .signers([pauser])
-                .rpc();
+    it("Should support fee-off mode for legacy SPL FUNDS call shape", async () => {
+      const usdtTokenRateLimitPda = getTokenRateLimitPda(
+        mockUSDT.mint.publicKey
+      );
 
-            const gasAmount = calculateSolAmount(2.5, solPrice);
-            const nativeSolTokenRateLimitPda = getTokenRateLimitPda(PublicKey.default);
+      await setProtocolFee(0);
+      try {
+        const userTokenAccount = await mockUSDT.createTokenAccount(
+          user1.publicKey
+        );
+        const gatewayTokenAccount = await mockUSDT.createTokenAccount(
+          vaultPda,
+          true
+        );
+        await mockUSDT.mintTo(userTokenAccount, 500);
+        const tokenAmount = new anchor.BN(200 * 10 ** mockUSDT.config.decimals);
+        const initialGatewayBalance = await mockUSDT.getBalance(
+          gatewayTokenAccount
+        );
 
-            const req = {
-                recipient: Array.from(Buffer.alloc(20, 0)),
-                token: PublicKey.default,
-                amount: new anchor.BN(0),
-                payload: Buffer.from([]),
-                revertInstruction: createRevertInstruction(user1.publicKey),
-                signatureData: Buffer.from("sig"),
-            };
+        const req = {
+          recipient: Array.from(Buffer.alloc(20, 2)),
+          token: mockUSDT.mint.publicKey,
+          amount: tokenAmount,
+          payload: Buffer.from([]),
+          revertInstruction: createRevertInstruction(user1.publicKey),
+          signatureData: Buffer.from("fee_off_legacy_spl_funds"),
+        };
 
-            try {
-                await program.methods
-                    .sendUniversalTx(req, new anchor.BN(gasAmount))
-                    .accounts({
-                        config: configPda,
-                        vault: vaultPda,
-                        userTokenAccount: vaultPda, // Dummy account for native SOL routes
-                        gatewayTokenAccount: vaultPda, // Dummy account for native SOL routes
-                        user: user1.publicKey,
-                        priceUpdate: mockPriceFeed,
-                        rateLimitConfig: rateLimitConfigPda,
-                        tokenRateLimit: nativeSolTokenRateLimitPda,
-                        tokenProgram: spl.TOKEN_PROGRAM_ID,
-                        systemProgram: SystemProgram.programId,
-                    })
-                    .signers([user1])
-                    .rpc();
-                expect.fail("Should reject when paused");
-            } catch (error: any) {
-                expect(error).to.exist;
-                expect(error.error?.errorCode?.code || error.code).to.equal("Paused");
-            }
+        await program.methods
+          .sendUniversalTx(req, new anchor.BN(0))
+          .accounts({
+            config: configPda,
+            vault: vaultPda,
+            feeVault: feeVaultPda,
+            userTokenAccount: userTokenAccount,
+            gatewayTokenAccount: gatewayTokenAccount,
+            user: user1.publicKey,
+            priceUpdate: mockPriceFeed,
+            rateLimitConfig: rateLimitConfigPda,
+            tokenRateLimit: usdtTokenRateLimitPda,
+            tokenProgram: spl.TOKEN_PROGRAM_ID,
+            systemProgram: SystemProgram.programId,
+          })
+          .signers([user1])
+          .rpc();
 
-            await program.methods
-                .unpause()
-                .accounts({ pauser: pauser.publicKey, config: configPda })
-                .signers([pauser])
-                .rpc();
-        });
-
-        it("Should reject invalid parameter combinations (no gas or funds)", async () => {
-            const nativeSolTokenRateLimitPda = getTokenRateLimitPda(PublicKey.default);
-
-            const req = {
-                recipient: Array.from(Buffer.alloc(20, 0)),
-                token: PublicKey.default,
-                amount: new anchor.BN(0),
-                payload: Buffer.from([]),
-                revertInstruction: createRevertInstruction(user1.publicKey),
-                signatureData: Buffer.from("sig"),
-            };
-
-            try {
-                await program.methods
-                    .sendUniversalTx(req, new anchor.BN(0))
-                    .accounts({
-                        config: configPda,
-                        vault: vaultPda,
-                        userTokenAccount: vaultPda,
-                        gatewayTokenAccount: vaultPda,
-                        user: user1.publicKey,
-                        priceUpdate: mockPriceFeed,
-                        rateLimitConfig: rateLimitConfigPda,
-                        tokenRateLimit: nativeSolTokenRateLimitPda,
-                        tokenProgram: spl.TOKEN_PROGRAM_ID,
-                        systemProgram: SystemProgram.programId,
-                    })
-                    .signers([user1])
-                    .rpc();
-                expect.fail("Should reject parameter set without gas or funds");
-            } catch (error: any) {
-                expect(error).to.exist;
-                const errorCode = error.error?.errorCode?.code || error.error?.errorCode || error.code;
-                expect(errorCode).to.equal("InvalidInput");
-            }
-        });
+        const finalGatewayBalance = await mockUSDT.getBalance(
+          gatewayTokenAccount
+        );
+        const balanceIncrease =
+          (finalGatewayBalance - initialGatewayBalance) *
+          10 ** mockUSDT.config.decimals;
+        expect(balanceIncrease).to.equal(tokenAmount.toNumber());
+      } finally {
+        await setProtocolFee(DEFAULT_PROTOCOL_FEE_LAMPORTS);
+      }
     });
+  });
 
-    after(async () => {
-        // Ensure contract is unpaused after all tests
-        try {
-            const config = await program.account.config.fetch(configPda);
-            if (config.paused) {
-                await program.methods
-                    .unpause()
-                    .accounts({ pauser: pauser.publicKey, config: configPda })
-                    .signers([pauser])
-                    .rpc();
-            }
-        } catch (error) {
-            // Ignore errors
-        }
+  after(async () => {
+    // Ensure contract is unpaused after all tests
+    try {
+      const config = await program.account.config.fetch(configPda);
+      if (config.paused) {
+        await program.methods
+          .unpause()
+          .accounts({ pauser: pauser.publicKey, config: configPda })
+          .signers([pauser])
+          .rpc();
+      }
+    } catch (error) {
+      // Ignore errors
+    }
 
-        // Disable rate limits to prevent interference with other tests
-        try {
-            // Disable epoch duration
-            await program.methods
-                .updateEpochDuration(new anchor.BN(0))
-                .accounts({
-                    admin: admin.publicKey,
-                    config: configPda,
-                    rateLimitConfig: rateLimitConfigPda,
-                    systemProgram: SystemProgram.programId,
-                })
-                .signers([admin])
-                .rpc();
+    // Disable rate limits to prevent interference with other tests
+    try {
+      await setProtocolFee(0);
 
-            // Set very large thresholds to effectively disable
-            const veryLargeThreshold = new anchor.BN("1000000000000000000000");
-            const nativeSolTokenRateLimitPda = getTokenRateLimitPda(PublicKey.default);
-            await program.methods
-                .setTokenRateLimit(veryLargeThreshold)
-                .accounts({
-                    admin: admin.publicKey,
-                    config: configPda,
-                    rateLimitConfig: rateLimitConfigPda,
-                    tokenRateLimit: nativeSolTokenRateLimitPda,
-                    tokenMint: PublicKey.default,
-                    systemProgram: SystemProgram.programId,
-                })
-                .signers([admin])
-                .rpc();
-        } catch (error) {
-            // Ignore errors
-        }
-    });
+      // Disable epoch duration
+      await program.methods
+        .updateEpochDuration(new anchor.BN(0))
+        .accounts({
+          admin: admin.publicKey,
+          config: configPda,
+          rateLimitConfig: rateLimitConfigPda,
+          systemProgram: SystemProgram.programId,
+        })
+        .signers([admin])
+        .rpc();
+
+      // Set very large thresholds to effectively disable
+      const veryLargeThreshold = new anchor.BN("1000000000000000000000");
+      const nativeSolTokenRateLimitPda = getTokenRateLimitPda(
+        PublicKey.default
+      );
+      await program.methods
+        .setTokenRateLimit(veryLargeThreshold)
+        .accounts({
+          admin: admin.publicKey,
+          config: configPda,
+          tokenRateLimit: nativeSolTokenRateLimitPda,
+          tokenMint: PublicKey.default,
+          systemProgram: SystemProgram.programId,
+        })
+        .signers([admin])
+        .rpc();
+    } catch (error) {
+      // Ignore errors
+    }
+  });
 });

--- a/contracts/svm-gateway/tests/withdraw.test.ts
+++ b/contracts/svm-gateway/tests/withdraw.test.ts
@@ -45,6 +45,7 @@ describe("Universal Gateway - Withdraw Tests", () => {
 
     let configPda: PublicKey;
     let vaultPda: PublicKey;
+    let feeVaultPda: PublicKey;
     let tssPda: PublicKey;
     let rateLimitConfigPda: PublicKey;
     let mockPriceFeed: PublicKey;
@@ -121,8 +122,25 @@ describe("Universal Gateway - Withdraw Tests", () => {
 
         [configPda] = PublicKey.findProgramAddressSync([Buffer.from("config")], program.programId);
         [vaultPda] = PublicKey.findProgramAddressSync([Buffer.from("vault")], program.programId);
+        [feeVaultPda] = PublicKey.findProgramAddressSync([Buffer.from("fee_vault")], program.programId);
         [tssPda] = PublicKey.findProgramAddressSync([Buffer.from("tsspda_v2")], program.programId);
         [rateLimitConfigPda] = PublicKey.findProgramAddressSync([Buffer.from("rate_limit_config")], program.programId);
+
+        // Ensure protocol fee is disabled for deterministic seeding in this suite.
+        await program.methods
+            .setProtocolFee(new anchor.BN(0))
+            .accounts({
+                config: configPda,
+                feeVault: feeVaultPda,
+                admin: admin.publicKey,
+                systemProgram: SystemProgram.programId,
+            })
+            .signers([admin])
+            .rpc();
+
+        // Seed fee_vault with a small amount to cover relayer gas reimbursements in revert tests
+        const feeVaultFundTx = await provider.connection.requestAirdrop(feeVaultPda, anchor.web3.LAMPORTS_PER_SOL);
+        await provider.connection.confirmTransaction(feeVaultFundTx);
 
         mockPriceFeed = sharedState.getMockPriceFeed();
 
@@ -146,24 +164,19 @@ describe("Universal Gateway - Withdraw Tests", () => {
         // Seed vault with native SOL using sendUniversalTx (FUNDS route)
         const nativeSolTokenRateLimitPda = getTokenRateLimitPda(PublicKey.default);
 
-        // Initialize native SOL token rate limit if needed
-        try {
-            await program.account.tokenRateLimit.fetch(nativeSolTokenRateLimitPda);
-        } catch {
-            const veryLargeThreshold = new anchor.BN("1000000000000000000000"); // Effectively unlimited
-            await program.methods
-                .setTokenRateLimit(veryLargeThreshold)
-                .accounts({
-                    config: configPda,
-                    rateLimitConfig: rateLimitConfigPda,
-                    tokenRateLimit: nativeSolTokenRateLimitPda,
-                    tokenMint: PublicKey.default,
-                    admin: admin.publicKey,
-                    systemProgram: SystemProgram.programId,
-                })
-                .signers([admin])
-                .rpc();
-        }
+        // Force a known non-zero threshold even if another suite previously set 0.
+        const veryLargeThreshold = new anchor.BN("1000000000000000000000"); // Effectively unlimited
+        await program.methods
+            .setTokenRateLimit(veryLargeThreshold)
+            .accounts({
+                config: configPda,
+                tokenRateLimit: nativeSolTokenRateLimitPda,
+                tokenMint: PublicKey.default,
+                admin: admin.publicKey,
+                systemProgram: SystemProgram.programId,
+            })
+            .signers([admin])
+            .rpc();
 
         // Deposit 8 SOL to vault for withdrawal tests (leave room for transaction fees)
         const solDepositAmount = 8 * anchor.web3.LAMPORTS_PER_SOL;
@@ -189,6 +202,7 @@ describe("Universal Gateway - Withdraw Tests", () => {
                 .accounts({
                     config: configPda,
                     vault: vaultPda,
+                    feeVault: feeVaultPda,
                     userTokenAccount: vaultPda, // Dummy account for native SOL routes
                     gatewayTokenAccount: vaultPda, // Dummy account for native SOL routes
                     user: user1.publicKey,
@@ -234,25 +248,18 @@ describe("Universal Gateway - Withdraw Tests", () => {
 
         const splTokenRateLimitPda = getTokenRateLimitPda(mockUSDT.mint.publicKey);
 
-        // Initialize token rate limit if needed (with very large threshold to effectively disable)
-        try {
-            await program.account.tokenRateLimit.fetch(splTokenRateLimitPda);
-        } catch {
-            // Not initialized, create it
-            const veryLargeThreshold = new anchor.BN("1000000000000000000000"); // Effectively unlimited
-            await program.methods
-                .setTokenRateLimit(veryLargeThreshold)
-                .accounts({
-                    config: configPda,
-                    rateLimitConfig: rateLimitConfigPda,
-                    tokenRateLimit: splTokenRateLimitPda,
-                    tokenMint: mockUSDT.mint.publicKey,
-                    admin: admin.publicKey,
-                    systemProgram: SystemProgram.programId,
-                })
-                .signers([admin])
-                .rpc();
-        }
+        // Force a known non-zero threshold even if another suite previously set 0.
+        await program.methods
+            .setTokenRateLimit(veryLargeThreshold)
+            .accounts({
+                config: configPda,
+                tokenRateLimit: splTokenRateLimitPda,
+                tokenMint: mockUSDT.mint.publicKey,
+                admin: admin.publicKey,
+                systemProgram: SystemProgram.programId,
+            })
+            .signers([admin])
+            .rpc();
 
         // Verify SPL deposit
         const vaultUsdtBalanceBefore = await mockUSDT.getBalance(vaultUsdtAccount);
@@ -263,6 +270,7 @@ describe("Universal Gateway - Withdraw Tests", () => {
                 .accounts({
                     config: configPda,
                     vault: vaultPda,
+                    feeVault: feeVaultPda,
                     user: user1.publicKey,
                     userTokenAccount: user1UsdtAccount,
                     gatewayTokenAccount: vaultUsdtAccount,
@@ -674,6 +682,7 @@ describe("Universal Gateway - Withdraw Tests", () => {
                 .accounts({
                     config: configPda,
                     vault: vaultPda,
+                    feeVault: feeVaultPda,
                     tssPda,
                     recipient: recipient.publicKey,
                     executedSubTx: executedTxPda,
@@ -691,6 +700,58 @@ describe("Universal Gateway - Withdraw Tests", () => {
             const actualRentForExecutedTx = 890880; // Approximate rent for 8-byte ExecutedSubTx account
             const expectedCallerGain = Number(DEFAULT_GAS_FEE) - actualRentForExecutedTx; // gas_fee minus rent for executed_sub_tx
             expect(callerBalanceChange).to.be.closeTo(expectedCallerGain, 100000); // Allow larger variance
+        });
+
+        it("rejects revert when fee_vault cannot reimburse gas fee", async () => {
+            const revertAmount = 1; // keep transfer leg minimal; only fee-pool check should fail
+            const tooLargeGasFee = BigInt(2 * anchor.web3.LAMPORTS_PER_SOL); // > seeded fee_vault in this suite
+
+            const subTxId = generateTxId();
+            const universalTxId = generateUniversalTxId();
+            const executedTxPda = getExecutedTxPda(subTxId);
+
+            const revertInstruction = {
+                fundRecipient: recipient.publicKey,
+                revertMsg: Buffer.from("insufficient fee pool"),
+            };
+
+            const signature = await signTssMessageWithChainId({
+                instruction: TssInstruction.RevertWithdrawSol,
+                amount: BigInt(revertAmount),
+                additional: [
+                    new Uint8Array(universalTxId),
+                    new Uint8Array(subTxId),
+                    toBytes(recipient.publicKey),
+                    buildGasFeeBuf(tooLargeGasFee),
+                ],
+            });
+
+            await expectRejection(
+                program.methods
+                    .revertUniversalTx(
+                        subTxId,
+                        universalTxId,
+                        new anchor.BN(revertAmount),
+                        revertInstruction,
+                        new anchor.BN(Number(tooLargeGasFee)),
+                        signature.signature,
+                        signature.recoveryId,
+                        signature.messageHash,
+                    )
+                    .accounts({
+                        config: configPda,
+                        vault: vaultPda,
+                        feeVault: feeVaultPda,
+                        tssPda,
+                        recipient: recipient.publicKey,
+                        executedSubTx: executedTxPda,
+                        caller: relayer.publicKey,
+                        systemProgram: SystemProgram.programId,
+                    })
+                    .signers([relayer])
+                    .rpc(),
+                "InsufficientFeePool"
+            );
         });
 
         it("reverts an SPL withdrawal with a valid signature", async () => {
@@ -733,6 +794,7 @@ describe("Universal Gateway - Withdraw Tests", () => {
                     config: configPda,
                     vault: vaultPda,
                     tokenVault: vaultUsdtAccount,
+                    feeVault: feeVaultPda,
                     tssPda,
                     recipientTokenAccount: recipientRevertAccount,
                     tokenMint: mockUSDT.mint.publicKey,
@@ -1128,6 +1190,7 @@ describe("Universal Gateway - Withdraw Tests", () => {
                     .accounts({
                         config: configPda,
                         vault: vaultPda,
+                        feeVault: feeVaultPda,
                         tssPda,
                         recipient: recipient.publicKey,
                         executedSubTx: executedTxPda,
@@ -1174,6 +1237,7 @@ describe("Universal Gateway - Withdraw Tests", () => {
                     .accounts({
                         config: configPda,
                         vault: vaultPda,
+                        feeVault: feeVaultPda,
                         tssPda,
                         recipient: recipient.publicKey, // Use valid recipient for account validation
                         executedSubTx: executedTxPda,
@@ -1236,6 +1300,7 @@ describe("Universal Gateway - Withdraw Tests", () => {
                 .accounts({
                     config: configPda,
                     vault: vaultPda,
+                    feeVault: feeVaultPda,
                     tssPda,
                     recipient: recipient.publicKey,
                     executedSubTx: executedTxPda,
@@ -1273,6 +1338,7 @@ describe("Universal Gateway - Withdraw Tests", () => {
                     .accounts({
                         config: configPda,
                         vault: vaultPda,
+                        feeVault: feeVaultPda,
                         tssPda,
                         recipient: recipient.publicKey,
                         executedSubTx: executedTxPda,
@@ -1334,6 +1400,7 @@ describe("Universal Gateway - Withdraw Tests", () => {
                         config: configPda,
                         vault: vaultPda,
                         tokenVault: vaultUsdtAccount,
+                        feeVault: feeVaultPda,
                         tssPda,
                         recipientTokenAccount: recipientRevertAccount,
                         tokenMint: mockUSDT.mint.publicKey,
@@ -1384,6 +1451,7 @@ describe("Universal Gateway - Withdraw Tests", () => {
                         config: configPda,
                         vault: vaultPda,
                         tokenVault: vaultUsdtAccount,
+                        feeVault: feeVaultPda,
                         tssPda,
                         recipientTokenAccount: recipientRevertAccount,
                         tokenMint: mockUSDT.mint.publicKey,
@@ -1435,6 +1503,7 @@ describe("Universal Gateway - Withdraw Tests", () => {
                     config: configPda,
                     vault: vaultPda,
                     tokenVault: vaultUsdtAccount,
+                    feeVault: feeVaultPda,
                     tssPda,
                     recipientTokenAccount: recipientRevertAccount,
                     tokenMint: mockUSDT.mint.publicKey,
@@ -1475,6 +1544,7 @@ describe("Universal Gateway - Withdraw Tests", () => {
                         config: configPda,
                         vault: vaultPda,
                         tokenVault: vaultUsdtAccount,
+                        feeVault: feeVaultPda,
                         tssPda,
                         recipientTokenAccount: recipientRevertAccount,
                         tokenMint: mockUSDT.mint.publicKey,


### PR DESCRIPTION
Adds protocol fees to SVM inbound send_universal_tx:


- Configurable flat protocol_fee (admin-set).
- Fee collected before routing.
- Fees isolated in fee_vault PDA (separate from bridged vault funds).
- Revert reimbursement now checks fee pool (InsufficientFeePool) so 1:1-backed bridge funds aren’t used.
- Updated scripts/tests for new feeVault account and fee-related negative cases.