### PR TITLE
83: UGPC Outbound fees in PC

### DIFF
--- a/contracts/evm-gateway/CLAUDE.md
+++ b/contracts/evm-gateway/CLAUDE.md
@@ -474,7 +474,7 @@ When a CEA sends `FUNDS_AND_PAYLOAD` with `msg.value > req.amount` (native batch
 
 ## UniversalGatewayPC - Outbound Transaction Handling
 
-**UniversalGatewayPC** is deployed on Push Chain and handles outbound transactions from Push Chain to external chains. It supports three TX_TYPE values (GAS is not supported on outbound).
+**UniversalGatewayPC** is deployed on Push Chain and handles outbound transactions from Push Chain to external chains. It supports three TX_TYPE values (GAS is not supported on outbound). Gas fees are paid in native PC, swapped to gas token PRC20 via UniversalCore's `swapPCForGasToken` (exactOutputSingle), and sent to VaultPC. Unused PC is refunded directly to the caller by UniversalCore.
 
 ### TX_TYPE Inference on Push Chain (`_fetchTxType()`)
 
@@ -525,7 +525,7 @@ function _fetchTxType(UniversalOutboundTxRequest calldata req) private pure retu
 
 ### Validation Flow
 
-**Function**: `_validateCommon(req.target, req.token, req.revertRecipient)`
+**Function**: `_validateCommon(req.token, req.revertRecipient)`
 
 
 **Note**: Amount validation is intentionally NOT in `_validateCommon()` because it's context-dependent:
@@ -540,7 +540,7 @@ Amount validation happens in `_fetchTxType()` which rejects empty transactions (
 
 2. **Conditional Token Burn**: Tokens are only burned when `amount > 0`. For payload-only transactions (GAS_AND_PAYLOAD with amount=0), the burn is skipped entirely.
 
-3. **Gas Fees Always Required**: Even for payload-only transactions, users must pay gas fees via `_moveFees()` to prevent spam/DoS.
+3. **Gas Fees Always Required**: Even for payload-only transactions, users must pay gas fees (native PC swapped via `_swapAndCollectFees()`) to prevent spam/DoS.
 
 4. **Supported TX_TYPEs on Push Chain**:
    - ✅ `TX_TYPE.FUNDS` - Withdraw tokens only
@@ -568,10 +568,18 @@ When testing UniversalGatewayPC:
 - `req.amount > 0` with empty payload → `TX_TYPE.FUNDS`
 - `req.amount > 0` with payload → `TX_TYPE.FUNDS_AND_PAYLOAD`
 
+### Gas Fee Swap Flow (exactOutputSingle)
+
+`sendUniversalTxOutbound` accepts native PC as `msg.value`, quotes the required `gasFee` via `_calculateGasFeesWithLimit()`, then calls `_swapAndCollectFees()` which delegates to `UniversalCore.swapPCForGasToken()`:
+
+1. UGPC passes `gasFee` as `requiredGasTokenOut` and `msg.sender` as `caller`
+2. UniversalCore performs an exactOutputSingle swap: produces exactly `requiredGasTokenOut` gas tokens to VaultPC
+3. UniversalCore refunds unused PC directly to `caller` (the original user)
+4. If the swap cannot produce the required output, UniversalCore reverts (no separate check in UGPC)
+
 ### Related Files
 
-- `src/UniversalGatewayPC.sol:83-119` - `sendUniversalTxOutbound()` main function
-- `src/UniversalGatewayPC.sol:141-166` - `_fetchTxType()` inference logic
-- `src/UniversalGatewayPC.sol:168-182` - `_validateCommon()` validation
-- `test/gateway/14_gatewayPC.t.sol` - Comprehensive test suite (79 tests)
+- `src/UniversalGatewayPC.sol` - `sendUniversalTxOutbound()`, `_swapAndCollectFees()`, `_fetchTxType()`
+- `src/interfaces/IUniversalCore.sol` - `swapPCForGasToken()` interface
+- `test/gateway/14_gatewayPC.t.sol` - Comprehensive test suite (82 tests)
 - `test/gateway/9_sendUniversalTxFetchTxType.t.sol` - TX_TYPE inference tests (27 tests)

--- a/contracts/evm-gateway/CLAUDE.md
+++ b/contracts/evm-gateway/CLAUDE.md
@@ -525,10 +525,10 @@ function _fetchTxType(UniversalOutboundTxRequest calldata req) private pure retu
 
 ### Validation Flow
 
-**Function**: `_validateCommon(req.token, req.revertRecipient)`
+**Function**: `_validateParams(req.token, req.revertRecipient)`
 
 
-**Note**: Amount validation is intentionally NOT in `_validateCommon()` because it's context-dependent:
+**Note**: Amount validation is intentionally NOT in `_validateParams()` because it's context-dependent:
 - For `FUNDS`: Amount must be > 0
 - For `GAS_AND_PAYLOAD`: Amount can be 0 (payload-only execution)
 

--- a/contracts/evm-gateway/docs/3_UniversalGatewayPC.md
+++ b/contracts/evm-gateway/docs/3_UniversalGatewayPC.md
@@ -1,101 +1,108 @@
 # UniversalGatewayPC — Outbound Gateway Overview
 
-A **UniversalGateway** is a chain-facing gateway contract that standardizes how users initiate cross-chain transactions.
+**UniversalGatewayPC** is the outbound gateway deployed **only on Push Chain**. It handles user requests to exit Push Chain back to an origin chain by burning PRC20 tokens and optionally attaching execution payloads.
 
-**UniversalGatewayPC** is the **outbound** gateway deployed **only on Push Chain**. It is used when a user wants to exit Push Chain back to an origin chain by withdrawing (burning) a token on Push Chain and optionally attaching an execution payload for the origin chain. It charges a protocol fee (gas fee) collected into **VaultPC**, burns the user’s token to represent the withdrawal request, and emits a single outbound event (`UniversalTxOutbound`) that drives the rest of the outbound pipeline.
-
----
-
-## 2. `sendUniversalTxOutbound` — Outbound Transaction Entry Point
-
-`sendUniversalTxOutbound(UniversalOutboundTxRequest req)` is the single public entry point for outbound requests from Push Chain.
-
-At a high level, the function performs the following actions:
-
-1. **Validate common request fields**
-   - `target` must be non-empty (destination address on origin chain, encoded as bytes).
-   - `token` must be non-zero.
-   - `amount` must be non-zero (burn amount).
-   - `revertRecipient` must be non-zero.
-
-2. **Infer the outbound transaction type (`TX_TYPE`)**
-   - The gateway does not require users to explicitly specify tx type.
-   - Instead it infers it using `_fetchTxType(req)` based on whether a payload exists and whether funds are included.
-
-3. **Calculate execution fees using `gasLimit`**
-   - Computes `gasToken`, `gasFee`, `gasLimitUsed`, and `protocolFee`.
-   - If `req.gasLimit == 0`, it defaults to `UniversalCore.BASE_GAS_LIMIT()`.
-
-4. **Collect the gas fee into VaultPC**
-   - Pulls `gasFee` from the user in `gasToken` into `VaultPC` via `transferFrom`.
-   - Requires the user to have approved `gasToken` to the gateway beforehand.
-
-5. **Burn PRC20 as the withdrawal representation**
-   - Pulls `amount` of `token` (PRC20) from the user into the gateway.
-   - Burns the PRC20 amount from the gateway’s balance.
-
-6. **Create a canonical outbound transaction ID**
-   - Uses an incrementing `nonce` and hashes the request fields to form `subTxId`.
-
-7. **Emit the outbound event**
-   - Emits `UniversalTxOutbound(...)` containing all essential data for relayers/executors.
+Gas fees are paid in native PC, swapped to the origin chain's gas token PRC20 via UniversalCore. The gas-cost portion (`gasFee`) is **burned** — freeing the backing tokens for TSS relayers to spend on origin-chain gas. The protocol-fee portion (`protocolFee`) is sent to **VaultPC** as revenue. Unused PC is refunded directly to the caller.
 
 ---
 
-### 2.1 `_fetchTxType(req)` — How TX_TYPE is inferred
+## 1. Contract Layout
 
-The outbound gateway infers `TX_TYPE` using two decision variables:
-
-- **hasPayload** = `req.payload.length > 0`
-- **hasFunds** = `req.amount > 0`
-
-| Inferred TX_TYPE            | hasPayload | hasFunds | Meaning                                                  |
-| --------------------------- | ---------- | -------- | -------------------------------------------------------- |
-| `TX_TYPE.FUNDS`             | NO         | YES      | Funds-only outbound withdrawal (burn → unlock on origin) |
-| `TX_TYPE.FUNDS_AND_PAYLOAD` | YES        | YES      | Withdraw funds and execute a payload on the origin chain |
-| `TX_TYPE.GAS_AND_PAYLOAD`   | YES        | NO       | Execute payload-only on origin chain (no funds burned)   |
-
-Notes:
-- In this contract version, `_validateCommon` currently requires `amount > 0`, which means the practical reachable types are `FUNDS` and `FUNDS_AND_PAYLOAD`.
-- `GAS_AND_PAYLOAD` exists in inference logic to support an execution-only route conceptually.
+| Section | Description |
+| --- | --- |
+| **UGPC_1: Admin Actions** | `initialize`, `pause`/`unpause`, `setVaultPC` |
+| **UGPC_2: Outbound TX** | `sendUniversalTxOutbound` — single public entry point |
+| **UGPC_3: Internal Helpers** | TX_TYPE inference, fee quoting, swap+burn, PRC20 burn |
 
 ---
 
-### 2.2 Gas limit and fee computation
+## 2. `sendUniversalTxOutbound` — Entry Point
 
-The gateway uses `_calculateGasFeesWithLimit(req.token, req.gasLimit)` to compute outbound execution fees:
+`sendUniversalTxOutbound(UniversalOutboundTxRequest calldata req)` is the single public entry point. It is `payable` (native PC for gas fees), `whenNotPaused`, and `nonReentrant`.
 
-- `gasLimitUsed`:
-  - If `req.gasLimit == 0`, use `UniversalCore.BASE_GAS_LIMIT()`
-  - Else use `req.gasLimit`
+**Execution flow:**
 
-- `(gasToken, gasFee)`:
-  - Fetched via `UniversalCore.withdrawGasFeeWithGasLimit(token, gasLimitUsed)`
-  - `gasToken` must be non-zero and `gasFee` must be non-zero.
-
-- `protocolFee`:
-  - Read from `PRC20(token).PC_PROTOCOL_FEE()`
-  - Represents the flat protocol fee portion included inside `gasFee`.
-
----
-
-### 2.3 Fee movement into VaultPC (Push Chain custody vault)
-
-Once fee parameters are computed, the gateway moves fees into `VaultPC`:
-
-- `_moveFees(msg.sender, gasToken, gasFee)` pulls `gasFee` using:
-  - `IPRC20(gasToken).transferFrom(from, VaultPC, gasFee)`
-- This makes **VaultPC the fee sink** for outbound flows.
-- If fee transfer fails, the transaction reverts.
+1. **Validate** — `token` must be non-zero, `revertRecipient` must be non-zero.
+2. **Infer TX_TYPE** — via `_fetchTxType(req)` based on payload and amount presence.
+3. **Quote fees** — via `_fetchOutboundTxInfo(req.token, req.gasLimit)` returning `gasToken`, `gasFee`, `gasLimitUsed`, `protocolFee`, and `chainNamespace`.
+4. **Burn PRC20** — if `amount > 0`, pulls and burns the user's PRC20 tokens.
+5. **Swap and split fees** — swaps `msg.value` (native PC) to gas token PRC20 via `UniversalCore.swapAndBurnGas()`:
+   - `gasFee` worth of gas token is **burned** (supply freed for TSS relayers).
+   - `protocolFee` worth of gas token is **sent to VaultPC** (protocol revenue).
+   - Unused PC is **refunded** to the caller.
+6. **Generate subTxId** — `keccak256(sender, recipient, token, amount, payloadHash, chainNamespace, nonce)`.
+7. **Emit `UniversalTxOutbound`** — contains all data for relayers/executors.
 
 ---
 
-### 2.4 PRC20 burn step
+### 2.1 TX_TYPE Inference (`_fetchTxType`)
 
-To represent withdrawal out of Push Chain:
+The gateway infers `TX_TYPE` from two decision variables — users never specify it explicitly:
 
-- The gateway pulls `amount` PRC20 from the user into itself.
-- It then calls `burn(amount)` on the PRC20 contract.
-- This ensures the gateway does **not custody** the withdrawn value—burning is the canonical on-chain representation of “exit requested”.
+| hasPayload | hasFunds (`amount > 0`) | TX_TYPE | Behavior |
+| --- | --- | --- | --- |
+| NO | YES | `FUNDS` | Burn tokens, unlock on origin chain |
+| YES | YES | `FUNDS_AND_PAYLOAD` | Burn tokens + execute payload on origin chain |
+| YES | NO | `GAS_AND_PAYLOAD` | Execute payload using existing CEA funds (no burn) |
+| NO | NO | — | Reverts with `InvalidInput` (empty transaction) |
+
+`GAS_AND_PAYLOAD` enables payload-only transactions where the user's CEA on the origin chain already holds sufficient funds for execution.
 
 ---
+
+### 2.2 Fee Quoting (`_fetchOutboundTxInfo`)
+
+Fetches gas fee quote and chain metadata from `UniversalCore.getOutboundTxGasAndFees(token, gasLimitUsed)`:
+
+- **`gasLimitUsed`** — if `req.gasLimit == 0`, defaults to `UniversalCore.BASE_GAS_LIMIT()`.
+- **`gasToken`** — the PRC20 gas token for the target chain (e.g., pETH for Ethereum).
+- **`gasFee`** — gas cost only: `gasPrice * gasLimit`. Excludes protocol fee.
+- **`protocolFee`** — flat protocol fee in gas token units.
+- **`chainNamespace`** — chain identifier string for the target chain.
+
+Reverts with `InvalidData` if `gasToken == address(0)` or `gasFee + protocolFee == 0`.
+
+---
+
+### 2.3 Fee Swap and Split (`_swapAndCollectFees`)
+
+The user pays gas fees in native PC via `msg.value`. The gateway calls `UniversalCore.swapAndBurnGas{value: msg.value}(...)` which:
+
+1. Swaps native PC → gas token PRC20 (total = `gasFee + protocolFee`).
+2. **Burns** the `gasFee` portion — the backing tokens on the origin chain are freed for TSS relayers to spend on execution gas.
+3. **Sends** the `protocolFee` portion to VaultPC as protocol revenue.
+4. **Refunds** any excess PC directly to the caller.
+
+This replaces the previous model where the entire fee was sent to VaultPC. The burn ensures no supply mismatch between the PRC20 representation on Push Chain and the backing tokens held by TSS on the origin chain.
+
+---
+
+### 2.4 PRC20 Burn (`_burnPRC20`)
+
+When `amount > 0`, the gateway:
+
+1. Pulls `amount` PRC20 from the user into itself via `transferFrom`.
+2. Burns the PRC20 via `burn(amount)`.
+
+The gateway never custodies withdrawn value — burning is the canonical on-chain representation of "exit requested". For `GAS_AND_PAYLOAD` (amount = 0), the burn step is skipped entirely.
+
+---
+
+## 3. Access Control
+
+| Role | Permissions |
+| --- | --- |
+| `DEFAULT_ADMIN_ROLE` | `initialize`, `setVaultPC` |
+| `PAUSER_ROLE` | `pause`, `unpause` |
+
+---
+
+## 4. Key Interfaces
+
+| Interface | Function | Purpose |
+| --- | --- | --- |
+| `IUniversalCore` | `BASE_GAS_LIMIT()` | Default gas limit when user passes 0 |
+| `IUniversalCore` | `getOutboundTxGasAndFees(token, gasLimit)` | Quote gas fee, protocol fee, gas token, chain namespace |
+| `IUniversalCore` | `swapAndBurnGas(gasToken, vault, fee, gasFee, protocolFee, deadline, caller)` | Swap PC → gas token, burn gasFee, send protocolFee to vault |
+| `IPRC20` | `transferFrom`, `burn` | Pull and burn PRC20 tokens |
+| `IVaultPC` | (address only) | Receives protocol fee portion of gas token |

--- a/contracts/evm-gateway/docs/4_OutboundTx_Flows.md
+++ b/contracts/evm-gateway/docs/4_OutboundTx_Flows.md
@@ -12,8 +12,8 @@ external EVM chain (Ethereum, Base, Arbitrum, etc.).
 
 | Chain          | Contract             | Role                                                                |
 | -------------- | -------------------- | ------------------------------------------------------------------- |
-| Push Chain     | `UniversalGatewayPC` | Outbound entry point; infers TX_TYPE; burns PRC20; collects fees    |
-| Push Chain     | `VaultPC`            | Receives gas fees from outbound requests                            |
+| Push Chain     | `UniversalGatewayPC` | Outbound entry point; infers TX_TYPE; burns PRC20; swaps PC for gas fees |
+| Push Chain     | `VaultPC`            | Receives protocol fee portion of gas fees (revenue)                      |
 | External Chain | `Vault`              | TSS-controlled custody; deploys/funds CEA; calls executeUniversalTx |
 | External Chain | `CEAFactory`         | Deterministic CREATE2 deployer for CEA contracts                    |
 | External Chain | `CEA`                | Per-UEA smart contract wallet; executes multicall payloads          |
@@ -33,11 +33,14 @@ external EVM chain (Ethereum, Base, Arbitrum, etc.).
 PRC20 tokens are wrapped representations of external chain tokens on Push Chain.
 
 - **Outbound withdrawal**: When `amount > 0`, `UniversalGatewayPC` burns PRC20 tokens from BOB. The corresponding tokens are released from `Vault` on the external chain.
-- **Gas fee**: Always collected in PRC20 (or designated gas token) via `_moveFees → VaultPC`, regardless of whether `amount > 0`.
+- **Gas fees**: Paid in **native PC** via `msg.value`. The gateway swaps PC → gas token PRC20 via `UniversalCore.swapAndBurnGas()`:
+  - **`gasFee`** (gas cost = `gasPrice × gasLimit`) is **burned** — freeing backing tokens on the origin chain for TSS relayers to spend on execution gas.
+  - **`protocolFee`** (flat fee in gas token units) is **sent to VaultPC** as protocol revenue.
+  - **Unused PC** is refunded directly to the caller.
 
 ### 1.4 TX_TYPE Reference
 
-#### Push Chain (`UniversalGatewayPC._fetchTxType`, `src/UniversalGatewayPC.sol:139-160`)
+#### Push Chain (`UniversalGatewayPC._fetchTxType`, `src/UniversalGatewayPC.sol:140-149`)
 
 | `req.payload` | `req.amount` | TX_TYPE             | PRC20 Burn | Description                                |
 | ------------- | ------------ | ------------------- | ---------- | ------------------------------------------ |
@@ -118,7 +121,7 @@ UniversalOutboundTxRequest({
 })
 ```
 
-**TX_TYPE**: `FUNDS`. Gateway collects gas fee, burns 1 PRC20-ETH, emits `UniversalTxOutbound`.
+**TX_TYPE**: `FUNDS`. Gateway swaps native PC → pETH (burns gasFee, sends protocolFee to VaultPC), burns 1 PRC20-ETH, emits `UniversalTxOutbound`.
 
 **TSS** observes the event and calls `Vault.finalizeUniversalTx{value: 1 ETH}`. Vault gets/deploys
 BOB's CEA, forwards 1 ETH to it, and calls `CEA.executeUniversalTx`.
@@ -130,13 +133,14 @@ calls[0] = Multicall({ to: recipientAddress, value: 1 ether, data: bytes("") });
 bytes memory data = abi.encode(calls);
 ```
 
-**Result**: `recipientAddress` on Ethereum receives 1 ETH. BOB's PRC20-ETH reduced by `amount + gasFee`.
+**Result**: `recipientAddress` on Ethereum receives 1 ETH. BOB's PRC20-ETH reduced by `amount` only (gas fees paid separately in native PC).
 
 ```mermaid
 sequenceDiagram
     autonumber
     participant BOB as BOB (UEA on Push Chain)
     participant GPC as UniversalGatewayPC (Push Chain)
+    participant UC as UniversalCore (Push Chain)
     participant VPC as VaultPC (Push Chain)
     participant TSS as TSS (off-chain relayer)
     participant V as Vault (Ethereum)
@@ -144,9 +148,12 @@ sequenceDiagram
     participant CEA as CEA (Ethereum)
     participant R as recipientAddress (Ethereum)
 
-    BOB->>GPC: sendUniversalTxOutbound(token=PRC20_ETH, amount=1ETH, payload="")
-    GPC->>VPC: collect gasFee from BOB
+    BOB->>GPC: sendUniversalTxOutbound{value: pcFee}(token=PRC20_ETH, amount=1ETH, payload="")
     GPC->>GPC: burn 1 PRC20-ETH from BOB
+    GPC->>UC: swapAndBurnGas{value: pcFee}(pETH, vault, gasFee, protocolFee)
+    UC->>UC: swap PC → pETH, burn gasFee
+    UC->>VPC: send protocolFee (pETH)
+    UC->>BOB: refund unused PC
     GPC-->>TSS: emit UniversalTxOutbound(subTxId, FUNDS)
 
     TSS->>V: finalizeUniversalTx{value:1ETH}(BOB_UEA, address(0), 1ETH, data)
@@ -178,13 +185,14 @@ calls[0] = Multicall({
 bytes memory data = abi.encode(calls);
 ```
 
-**Result**: `recipientAddress` on Ethereum receives 1000 USDC.
+**Result**: `recipientAddress` on Ethereum receives 1000 USDC. Gas fees paid separately in native PC (swapped to pETH, gasFee burned, protocolFee to VaultPC).
 
 ```mermaid
 sequenceDiagram
     autonumber
     participant BOB as BOB (UEA on Push Chain)
     participant GPC as UniversalGatewayPC (Push Chain)
+    participant UC as UniversalCore (Push Chain)
     participant VPC as VaultPC (Push Chain)
     participant TSS as TSS (off-chain relayer)
     participant V as Vault (Ethereum)
@@ -193,9 +201,12 @@ sequenceDiagram
     participant USDC as USDC Token (Ethereum)
     participant R as recipientAddress (Ethereum)
 
-    BOB->>GPC: sendUniversalTxOutbound(token=PRC20_USDC, amount=1000e6, payload="")
-    GPC->>VPC: collect gasFee from BOB
+    BOB->>GPC: sendUniversalTxOutbound{value: pcFee}(token=PRC20_USDC, amount=1000e6, payload="")
     GPC->>GPC: burn 1000e6 PRC20-USDC from BOB
+    GPC->>UC: swapAndBurnGas{value: pcFee}(pETH, vault, gasFee, protocolFee)
+    UC->>UC: swap PC → pETH, burn gasFee
+    UC->>VPC: send protocolFee (pETH)
+    UC->>BOB: refund unused PC
     GPC-->>TSS: emit UniversalTxOutbound(subTxId, FUNDS)
 
     TSS->>V: finalizeUniversalTx{value:0}(BOB_UEA, USDC, 1000e6, data)
@@ -228,13 +239,14 @@ calls[0] = Multicall({ to: recipientAddress, value: 0.5 ether, data: bytes("") }
 bytes memory data = abi.encode(calls);
 ```
 
-**Result**: `recipientAddress` receives 0.5 ETH. BOB's PRC20-ETH is unchanged (no burn).
+**Result**: `recipientAddress` receives 0.5 ETH. BOB's PRC20-ETH is unchanged (no burn). Gas fees paid in native PC.
 
 ```mermaid
 sequenceDiagram
     autonumber
     participant BOB as BOB (UEA on Push Chain)
     participant GPC as UniversalGatewayPC (Push Chain)
+    participant UC as UniversalCore (Push Chain)
     participant VPC as VaultPC (Push Chain)
     participant TSS as TSS (off-chain relayer)
     participant V as Vault (Ethereum)
@@ -242,9 +254,12 @@ sequenceDiagram
     participant R as recipientAddress (Ethereum)
 
     Note over CEA: CEA holds 0.5 ETH (pre-existing)
-    BOB->>GPC: sendUniversalTxOutbound(amount=0, payload=multicallCalldata)
-    GPC->>VPC: collect gasFee from BOB
+    BOB->>GPC: sendUniversalTxOutbound{value: pcFee}(amount=0, payload=multicallCalldata)
     Note over GPC: No burn (amount == 0)
+    GPC->>UC: swapAndBurnGas{value: pcFee}(pETH, vault, gasFee, protocolFee)
+    UC->>UC: swap PC → pETH, burn gasFee
+    UC->>VPC: send protocolFee (pETH)
+    UC->>BOB: refund unused PC
     GPC-->>TSS: emit UniversalTxOutbound(subTxId, GAS_AND_PAYLOAD)
 
     TSS->>V: finalizeUniversalTx{value:0}(BOB_UEA, address(0), 0, data)
@@ -276,13 +291,14 @@ calls[0] = Multicall({
 bytes memory data = abi.encode(calls);
 ```
 
-**Result**: `recipientAddress` receives 200 USDC. CEA's USDC balance reduced. No PRC20 burned.
+**Result**: `recipientAddress` receives 200 USDC. CEA's USDC balance reduced. No PRC20 burned. Gas fees paid in native PC.
 
 ```mermaid
 sequenceDiagram
     autonumber
     participant BOB as BOB (UEA on Push Chain)
     participant GPC as UniversalGatewayPC (Push Chain)
+    participant UC as UniversalCore (Push Chain)
     participant VPC as VaultPC (Push Chain)
     participant TSS as TSS (off-chain relayer)
     participant V as Vault (Ethereum)
@@ -291,9 +307,12 @@ sequenceDiagram
     participant R as recipientAddress (Ethereum)
 
     Note over CEA: CEA holds 200e6 USDC (pre-existing)
-    BOB->>GPC: sendUniversalTxOutbound(amount=0, payload=multicallCalldata)
-    GPC->>VPC: collect gasFee from BOB
+    BOB->>GPC: sendUniversalTxOutbound{value: pcFee}(amount=0, payload=multicallCalldata)
     Note over GPC: No burn (amount == 0)
+    GPC->>UC: swapAndBurnGas{value: pcFee}(pETH, vault, gasFee, protocolFee)
+    UC->>UC: swap PC → pETH, burn gasFee
+    UC->>VPC: send protocolFee (pETH)
+    UC->>BOB: refund unused PC
     GPC-->>TSS: emit UniversalTxOutbound(subTxId, GAS_AND_PAYLOAD)
 
     TSS->>V: finalizeUniversalTx{value:0}(BOB_UEA, address(0), 0, data)
@@ -335,20 +354,26 @@ calls[0] = Multicall({
 bytes memory data = abi.encode(calls);
 ```
 
-**Result**: Swap output tokens arrive in CEA. BOB's PRC20-ETH reduced by `1 ether + gasFee`.
+**Result**: Swap output tokens arrive in CEA. BOB's PRC20-ETH reduced by `1 ether` only (gas fees paid separately in native PC).
 
 ```mermaid
 sequenceDiagram
     autonumber
     participant BOB as BOB (UEA on Push Chain)
     participant GPC as UniversalGatewayPC (Push Chain)
+    participant UC as UniversalCore (Push Chain)
+    participant VPC as VaultPC (Push Chain)
     participant TSS as TSS (off-chain relayer)
     participant V as Vault (Ethereum)
     participant CEA as CEA (Ethereum)
     participant T as Uniswap Router (Ethereum)
 
-    BOB->>GPC: sendUniversalTxOutbound(token=PRC20_ETH, amount=1ETH, payload=swapCalldata)
+    BOB->>GPC: sendUniversalTxOutbound{value: pcFee}(token=PRC20_ETH, amount=1ETH, payload=swapCalldata)
     GPC->>GPC: burn 1 PRC20-ETH from BOB
+    GPC->>UC: swapAndBurnGas{value: pcFee}(pETH, vault, gasFee, protocolFee)
+    UC->>UC: swap PC → pETH, burn gasFee
+    UC->>VPC: send protocolFee (pETH)
+    UC->>BOB: refund unused PC
     GPC-->>TSS: emit UniversalTxOutbound(subTxId, FUNDS_AND_PAYLOAD)
 
     TSS->>V: finalizeUniversalTx{value:1ETH}(BOB_UEA, address(0), 1ETH, data)
@@ -376,21 +401,27 @@ calls[0] = Multicall({ to: TARGET_CONTRACT, value: 0.5 ether, data: targetCallda
 bytes memory data = abi.encode(calls);
 ```
 
-**Result**: CEA ETH balance reduced by 0.5. No PRC20 burned.
+**Result**: CEA ETH balance reduced by 0.5. No PRC20 burned. Gas fees paid in native PC.
 
 ```mermaid
 sequenceDiagram
     autonumber
     participant BOB as BOB (UEA on Push Chain)
     participant GPC as UniversalGatewayPC (Push Chain)
+    participant UC as UniversalCore (Push Chain)
+    participant VPC as VaultPC (Push Chain)
     participant TSS as TSS (off-chain relayer)
     participant V as Vault (Ethereum)
     participant CEA as CEA (Ethereum)
     participant T as Target Protocol (Ethereum)
 
     Note over CEA: CEA already holds 0.5 ETH
-    BOB->>GPC: sendUniversalTxOutbound(amount=0, payload=targetCalldata)
+    BOB->>GPC: sendUniversalTxOutbound{value: pcFee}(amount=0, payload=targetCalldata)
     Note over GPC: No burn
+    GPC->>UC: swapAndBurnGas{value: pcFee}(pETH, vault, gasFee, protocolFee)
+    UC->>UC: swap PC → pETH, burn gasFee
+    UC->>VPC: send protocolFee (pETH)
+    UC->>BOB: refund unused PC
     GPC-->>TSS: emit UniversalTxOutbound(subTxId, GAS_AND_PAYLOAD)
 
     TSS->>V: finalizeUniversalTx{value:0}(BOB_UEA, address(0), 0, data)
@@ -423,14 +454,20 @@ sequenceDiagram
     autonumber
     participant BOB as BOB (UEA on Push Chain)
     participant GPC as UniversalGatewayPC (Push Chain)
+    participant UC as UniversalCore (Push Chain)
+    participant VPC as VaultPC (Push Chain)
     participant TSS as TSS (off-chain relayer)
     participant V as Vault (Ethereum)
     participant CEA as CEA (Ethereum)
     participant T as Target Protocol (Ethereum)
 
     Note over CEA: CEA holds 0.3 ETH pre-existing
-    BOB->>GPC: sendUniversalTxOutbound(token=PRC20_ETH, amount=0.5ETH, payload=targetCalldata)
+    BOB->>GPC: sendUniversalTxOutbound{value: pcFee}(token=PRC20_ETH, amount=0.5ETH, payload=targetCalldata)
     GPC->>GPC: burn 0.5 PRC20-ETH from BOB
+    GPC->>UC: swapAndBurnGas{value: pcFee}(pETH, vault, gasFee, protocolFee)
+    UC->>UC: swap PC → pETH, burn gasFee
+    UC->>VPC: send protocolFee (pETH)
+    UC->>BOB: refund unused PC
     GPC-->>TSS: emit UniversalTxOutbound(subTxId, FUNDS_AND_PAYLOAD)
 
     TSS->>V: finalizeUniversalTx{value:0.5ETH}(BOB_UEA, address(0), 0.5ETH, data)
@@ -456,21 +493,27 @@ calls[1] = Multicall({ to: AAVE_POOL, value: 0, data: abi.encodeCall(IAavePool.s
 bytes memory data = abi.encode(calls);
 ```
 
-**Result**: CEA holds aUSDC receipt tokens. BOB's PRC20-USDC reduced by `500e6 + gasFee`.
+**Result**: CEA holds aUSDC receipt tokens. BOB's PRC20-USDC reduced by `500e6` only (gas fees paid separately in native PC).
 
 ```mermaid
 sequenceDiagram
     autonumber
     participant BOB as BOB (UEA on Push Chain)
     participant GPC as UniversalGatewayPC (Push Chain)
+    participant UC as UniversalCore (Push Chain)
+    participant VPC as VaultPC (Push Chain)
     participant TSS as TSS (off-chain relayer)
     participant V as Vault (Ethereum)
     participant CEA as CEA (Ethereum)
     participant USDC as USDC Token
     participant AAVE as Aave Pool (Ethereum)
 
-    BOB->>GPC: sendUniversalTxOutbound(token=PRC20_USDC, amount=500e6, payload=aaveCalldata)
+    BOB->>GPC: sendUniversalTxOutbound{value: pcFee}(token=PRC20_USDC, amount=500e6, payload=aaveCalldata)
     GPC->>GPC: burn 500e6 PRC20-USDC from BOB
+    GPC->>UC: swapAndBurnGas{value: pcFee}(pETH, vault, gasFee, protocolFee)
+    UC->>UC: swap PC → pETH, burn gasFee
+    UC->>VPC: send protocolFee (pETH)
+    UC->>BOB: refund unused PC
     GPC-->>TSS: emit UniversalTxOutbound(subTxId, FUNDS_AND_PAYLOAD)
 
     TSS->>V: finalizeUniversalTx{value:0}(BOB_UEA, USDC, 500e6, data)
@@ -534,7 +577,8 @@ Only `FUNDS` and `FUNDS_AND_PAYLOAD` are currently active for CEA→UEA routes.
 
 The general flow for all Category 3 cases:
 ```
-BOB: sendUniversalTxOutbound(amount>0, payload=<multicallData>)  [FUNDS_AND_PAYLOAD, burns PRC20]
+BOB: sendUniversalTxOutbound{value: pcFee}(amount>0, payload=<multicallData>)
+  [FUNDS_AND_PAYLOAD, burns PRC20, swaps PC → gas token (burn gasFee, protocolFee to VaultPC)]
   → TSS: Vault.finalizeUniversalTx(BOB_UEA, ..., data=<multicallData>)
   → CEA.executeUniversalTx(data)  [Vault supplies tokens to CEA]
   → multicall: [..., sendUniversalTxFromCEA(req{recipient=BOB_UEA})]
@@ -578,13 +622,19 @@ sequenceDiagram
     autonumber
     participant BOB as BOB (UEA on Push Chain)
     participant GPC as UniversalGatewayPC (Push Chain)
+    participant UC as UniversalCore (Push Chain)
+    participant VPC as VaultPC (Push Chain)
     participant TSS as TSS (off-chain relayer)
     participant V as Vault (Ethereum)
     participant CEA as CEA (Ethereum)
     participant GW as UniversalGateway (Ethereum)
 
-    BOB->>GPC: sendUniversalTxOutbound(token=PRC20_ETH, amount=ethAmount, payload=multicallData)
+    BOB->>GPC: sendUniversalTxOutbound{value: pcFee}(token=PRC20_ETH, amount=ethAmount, payload=multicallData)
     GPC->>GPC: burn ethAmount PRC20-ETH from BOB
+    GPC->>UC: swapAndBurnGas{value: pcFee}(pETH, vault, gasFee, protocolFee)
+    UC->>UC: swap PC → pETH, burn gasFee
+    UC->>VPC: send protocolFee (pETH)
+    UC->>BOB: refund unused PC
     GPC-->>TSS: emit UniversalTxOutbound(subTxId, FUNDS_AND_PAYLOAD)
 
     TSS->>V: finalizeUniversalTx{value:ethAmount}(BOB_UEA, address(0), ethAmount, data)
@@ -635,14 +685,20 @@ sequenceDiagram
     autonumber
     participant BOB as BOB (UEA on Push Chain)
     participant GPC as UniversalGatewayPC (Push Chain)
+    participant UC as UniversalCore (Push Chain)
+    participant VPC as VaultPC (Push Chain)
     participant TSS as TSS (off-chain relayer)
     participant V as Vault (Ethereum)
     participant CEA as CEA (Ethereum)
     participant GW as UniversalGateway (Ethereum)
     participant USDC as USDC Token
 
-    BOB->>GPC: sendUniversalTxOutbound(token=PRC20_USDC, amount=500e6, payload=multicallData)
+    BOB->>GPC: sendUniversalTxOutbound{value: pcFee}(token=PRC20_USDC, amount=500e6, payload=multicallData)
     GPC->>GPC: burn 500e6 PRC20-USDC from BOB
+    GPC->>UC: swapAndBurnGas{value: pcFee}(pETH, vault, gasFee, protocolFee)
+    UC->>UC: swap PC → pETH, burn gasFee
+    UC->>VPC: send protocolFee (pETH)
+    UC->>BOB: refund unused PC
     GPC-->>TSS: emit UniversalTxOutbound(subTxId, FUNDS_AND_PAYLOAD)
 
     TSS->>V: finalizeUniversalTx{value:0}(BOB_UEA, USDC, 500e6, data)
@@ -958,6 +1014,7 @@ sequenceDiagram
     autonumber
     participant BOB as BOB (UEA on Push Chain)
     participant GPC as UniversalGatewayPC (Push Chain)
+    participant UC as UniversalCore (Push Chain)
     participant VPC as VaultPC (Push Chain)
     participant TSS as TSS (off-chain relayer)
     participant V as Vault (Ethereum)
@@ -965,9 +1022,12 @@ sequenceDiagram
     participant CF as CEAFactory (Ethereum)
     participant MC as MigrationContract (Ethereum)
 
-    BOB->>GPC: sendUniversalTxOutbound(amount=0, payload=MIGRATION_SELECTOR)
-    GPC->>VPC: collect gasFee from BOB
+    BOB->>GPC: sendUniversalTxOutbound{value: pcFee}(amount=0, payload=MIGRATION_SELECTOR)
     Note over GPC: No burn (amount == 0)
+    GPC->>UC: swapAndBurnGas{value: pcFee}(pETH, vault, gasFee, protocolFee)
+    UC->>UC: swap PC → pETH, burn gasFee
+    UC->>VPC: send protocolFee (pETH)
+    UC->>BOB: refund unused PC
     GPC-->>TSS: emit UniversalTxOutbound(subTxId, GAS_AND_PAYLOAD)
 
     TSS->>V: finalizeUniversalTx{value:0}(BOB_UEA, address(0), 0, migrationPayload)

--- a/contracts/evm-gateway/lcov.info
+++ b/contracts/evm-gateway/lcov.info
@@ -877,8 +877,8 @@ DA:119,9
 DA:121,8
 DA:122,8
 DA:135,35
-FN:135,UniversalGatewayPC._validateCommon
-FNDA:35,UniversalGatewayPC._validateCommon
+FN:135,UniversalGatewayPC._validateParams
+FNDA:35,UniversalGatewayPC._validateParams
 DA:141,35
 BRDA:141,2,0,2
 DA:142,33

--- a/contracts/evm-gateway/script/vaultPC/deployVaultPC.s.sol
+++ b/contracts/evm-gateway/script/vaultPC/deployVaultPC.s.sol
@@ -159,7 +159,7 @@ contract DeployVaultPC is Script {
         // Verify roles
         require(vaultPC.hasRole(vaultPC.DEFAULT_ADMIN_ROLE(), admin), "Admin role not set");
         require(vaultPC.hasRole(vaultPC.PAUSER_ROLE(), pauser), "Pauser role not set");
-        require(vaultPC.hasRole(vaultPC.FUND_MANAGER_ROLE(), fundManager), "Fund Manager role not set");
+        require(vaultPC.hasRole(vaultPC.MANAGER_ROLE(), fundManager), "Manager role not set");
 
         console.log("OK: All roles assigned correctly");
         console.log("");

--- a/contracts/evm-gateway/src/UniversalGateway.sol
+++ b/contracts/evm-gateway/src/UniversalGateway.sol
@@ -109,7 +109,7 @@ contract UniversalGateway is
     address public CEA_FACTORY;
 
     /// @notice Flat protocol fee in native token (wei). 0 = disabled.
-    uint256 public PROTOCOL_FEE;
+    uint256 public PROTOCOL_FEE; // INBOUND_FEE
 
     /// @notice Running total of protocol fees collected (native, in wei).
     uint256 public totalProtocolFeesCollected;
@@ -974,10 +974,7 @@ contract UniversalGateway is
     /// @param nativeValue      Raw native value received with the transaction
     /// @return adjustedNative  nativeValue minus the collected fee
     /// @return feeCollected    Amount forwarded to TSS as the protocol fee
-    function _collectProtocolFee(uint256 nativeValue)
-        private
-        returns (uint256 adjustedNative, uint256 feeCollected)
-    {
+    function _collectProtocolFee(uint256 nativeValue) private returns (uint256 adjustedNative, uint256 feeCollected) {
         uint256 fee = PROTOCOL_FEE;
         if (fee == 0) return (nativeValue, 0);
 

--- a/contracts/evm-gateway/src/UniversalGateway.sol
+++ b/contracts/evm-gateway/src/UniversalGateway.sol
@@ -366,7 +366,7 @@ contract UniversalGateway is
         if (CEA_FACTORY == address(0)) revert Errors.InvalidInput();
         if (!_isCallerCEA()) revert Errors.InvalidInput();
 
-        address mappedUEA = ICEAFactory(CEA_FACTORY).getUEAForCEA(_msgSender());
+        address mappedUEA = ICEAFactory(CEA_FACTORY).getPushAccountForCEA(_msgSender());
         if (mappedUEA == address(0)) revert Errors.InvalidInput();
 
         if (req.recipient != mappedUEA) revert Errors.InvalidRecipient();

--- a/contracts/evm-gateway/src/UniversalGatewayPC.sol
+++ b/contracts/evm-gateway/src/UniversalGatewayPC.sol
@@ -82,7 +82,12 @@ contract UniversalGatewayPC is
         _unpause();
     }
 
-    function sendUniversalTxOutbound(UniversalOutboundTxRequest calldata req) external payable whenNotPaused nonReentrant {
+    function sendUniversalTxOutbound(UniversalOutboundTxRequest calldata req)
+        external
+        payable
+        whenNotPaused
+        nonReentrant
+    {
         _validateCommon(req.token, req.revertRecipient);
 
         // Determine TX_TYPE based on user input (rejects empty transactions internally)
@@ -97,9 +102,8 @@ contract UniversalGatewayPC is
             _burnPRC20(msg.sender, req.token, req.amount);
         }
 
-        // Swap native PC → gas token PRC20 → VaultPC; verify output covers quoted gasFee
-        uint256 gasTokenOut = _swapAndCollectFees(req.token, msg.value);
-        if (gasTokenOut < gasFee) revert Errors.InsufficientProtocolFee();
+        // Swap native PC → gas token PRC20 → VaultPC (exactOutputSingle: reverts if insufficient)
+        _swapAndCollectFees(req.token, msg.value, gasFee);
 
         string memory chainNamespace = IPRC20(req.token).SOURCE_CHAIN_NAMESPACE();
 
@@ -199,22 +203,18 @@ contract UniversalGatewayPC is
     }
 
     /**
-     * @dev     Swap native PC → gas token PRC20 via UniversalCore, sending output to VaultPC.
+     * @dev     Swap native PC → gas token PRC20 via UniversalCore (exactOutputSingle), sending output to VaultPC.
+     *          UniversalCore refunds any unused PC directly to the caller.
      * @param prc20    PRC20 token address (used by UniversalCore to resolve the swap pair).
      * @param pcAmount Native PC amount (msg.value) to swap.
+     * @param gasFee   Exact gas token output required (passed as requiredGasTokenOut).
      */
-    function _swapAndCollectFees(
-        address prc20,
-        uint256 pcAmount
-    ) internal returns (uint256 gasTokenOut) {
+    function _swapAndCollectFees(address prc20, uint256 pcAmount, uint256 gasFee) internal {
         if (pcAmount == 0) revert Errors.ZeroAmount();
         address vault = address(VAULT_PC);
         if (vault == address(0)) revert Errors.ZeroAddress();
 
-        gasTokenOut = IUniversalCore(UNIVERSAL_CORE)
-            .swapPCForGasToken{value: pcAmount}(
-                prc20, vault, 0, 0, 0
-            );
+        IUniversalCore(UNIVERSAL_CORE).swapPCForGasToken{ value: pcAmount }(prc20, vault, 0, gasFee, 0, msg.sender);
     }
 
     function _burnPRC20(address from, address token, uint256 amount) internal {

--- a/contracts/evm-gateway/src/UniversalGatewayPC.sol
+++ b/contracts/evm-gateway/src/UniversalGatewayPC.sol
@@ -3,15 +3,17 @@ pragma solidity 0.8.26;
 
 /**
  * @title   UniversalGatewayPC
- * @notice  Universal Gateway implementation for Push Chain
+ * @notice  Outbound gateway on Push Chain for bridging funds and payloads to external EVM chains.
  *
  * @dev
  *         - Strictly to be deployed on Push Chain.
  *         - Allows users to withdraw PRC20 (wrapped) tokens back to the origin chain.
  *         - Allows users to withdraw PRC20 and attach a payload for arbitrary call execution on the origin chain.
+ *         - Allows payload-only transactions (no token burn) using existing CEA funds on the origin chain.
  *         - This contract does NOT handle deposits or inbound transfers.
  *         - This contract does NOT custody user assets; PRC20 are burned at request time.
- *         - The Gateway includes a withdrawal fees for withdrwal from Push Chain to origin chain.
+ *         - Gas fees are paid in native PC, swapped to gas token PRC20 via UniversalCore (exactOutputSingle),
+ *           and sent to VaultPC. Unused PC is refunded directly to the caller by UniversalCore.
  */
 import { Errors } from "./libraries/Errors.sol";
 import { IPRC20 } from "./interfaces/IPRC20.sol";
@@ -82,6 +84,11 @@ contract UniversalGatewayPC is
         _unpause();
     }
 
+    /// @notice Sends an outbound universal transaction from Push Chain to an external chain.
+    /// @dev    Infers TX_TYPE from the request, quotes gas fees, burns PRC20 (if amount > 0),
+    ///         swaps native PC to gas token PRC20 via UniversalCore exactOutputSingle (refunding
+    ///         unused PC directly to the caller), and emits UniversalTxOutbound.
+    /// @param req The outbound transaction request struct.
     function sendUniversalTxOutbound(UniversalOutboundTxRequest calldata req)
         external
         payable
@@ -169,7 +176,7 @@ contract UniversalGatewayPC is
 
     /// @notice                 Validates the common parameters.
     /// @dev                    Validates token and revertRecipient addresses.
-    ///                         Amount validation is handled in sendUniversalTxOutbound() to support payload-only transactions.
+    ///                         Amount validation is handled in _fetchTxType() to support payload-only transactions.
     /// @param token            PRC20 token address on Push Chain.
     /// @param revertRecipient  address to receive funds in case of revert.
     function _validateCommon(address token, address revertRecipient) internal pure {
@@ -179,11 +186,13 @@ contract UniversalGatewayPC is
 
     /**
      * @dev                 Use UniversalCore's withdrawGasFeeWithGasLimit to compute fee (gas coin + amount).
-     *                          If gasLimit = 0, pull the default BASE_GAS_LIMIT from UniversalCore.
-     * @return gasToken     PRC20 address to be used for fee payment.
-     * @return gasFee       amount of gasToken to collect from the user (includes protocol fee).
-     * @return gasLimitUsed gas limit actually used for the quote.
-     * @return protocolFee  the flat protocol fee component (as exposed by PRC20).
+     *                      If gasLimit = 0, pull the default BASE_GAS_LIMIT from UniversalCore.
+     * @param token         PRC20 token address on Push Chain (used to resolve chain namespace and protocol fee).
+     * @param gasLimit      Caller-requested gas limit (0 = use BASE_GAS_LIMIT from UniversalCore).
+     * @return gasToken     PRC20 address of the gas token for the target chain.
+     * @return gasFee       Amount of gasToken to collect (includes protocol fee).
+     * @return gasLimitUsed Gas limit actually used for the quote.
+     * @return protocolFee  Flat protocol fee component (as exposed by PRC20).
      */
     function _calculateGasFeesWithLimit(address token, uint256 gasLimit)
         internal
@@ -217,6 +226,7 @@ contract UniversalGatewayPC is
         IUniversalCore(UNIVERSAL_CORE).swapPCForGasToken{ value: pcAmount }(prc20, vault, 0, gasFee, 0, msg.sender);
     }
 
+    /// @dev Pulls PRC20 from `from` into this contract, then burns them.
     function _burnPRC20(address from, address token, uint256 amount) internal {
         // Pull PRC20 into this gateway first
         IPRC20(token).transferFrom(from, address(this), amount);

--- a/contracts/evm-gateway/src/UniversalGatewayPC.sol
+++ b/contracts/evm-gateway/src/UniversalGatewayPC.sol
@@ -82,21 +82,24 @@ contract UniversalGatewayPC is
         _unpause();
     }
 
-    function sendUniversalTxOutbound(UniversalOutboundTxRequest calldata req) external whenNotPaused nonReentrant {
+    function sendUniversalTxOutbound(UniversalOutboundTxRequest calldata req) external payable whenNotPaused nonReentrant {
         _validateCommon(req.token, req.revertRecipient);
 
         // Determine TX_TYPE based on user input (rejects empty transactions internally)
         TX_TYPE txType = _fetchTxType(req);
 
-        // Compute fees + collect from caller into the UEM fee sink
+        // Quote for event data (gasToken address, gasFee, protocolFee)
         (address gasToken, uint256 gasFee, uint256 gasLimitUsed, uint256 protocolFee) =
             _calculateGasFeesWithLimit(req.token, req.gasLimit);
-        _moveFees(msg.sender, gasToken, gasFee);
 
-        // Only burn tokens if amount > 0 (supports payload-only transactions where CEA already has funds)
+        // Burn PRC20 first (if amount > 0), before swap
         if (req.amount > 0) {
             _burnPRC20(msg.sender, req.token, req.amount);
         }
+
+        // Swap native PC → gas token PRC20 → VaultPC; verify output covers quoted gasFee
+        uint256 gasTokenOut = _swapAndCollectFees(req.token, msg.value);
+        if (gasTokenOut < gasFee) revert Errors.InsufficientProtocolFee();
 
         string memory chainNamespace = IPRC20(req.token).SOURCE_CHAIN_NAMESPACE();
 
@@ -120,7 +123,8 @@ contract UniversalGatewayPC is
             req.payload,
             protocolFee,
             req.revertRecipient,
-            txType
+            txType,
+            msg.value
         );
     }
 
@@ -195,15 +199,22 @@ contract UniversalGatewayPC is
     }
 
     /**
-     * @dev     Pull fee from user into the VaultPC.
-     *          Caller must have approved `gasToken` for at least `gasFee`.
+     * @dev     Swap native PC → gas token PRC20 via UniversalCore, sending output to VaultPC.
+     * @param prc20    PRC20 token address (used by UniversalCore to resolve the swap pair).
+     * @param pcAmount Native PC amount (msg.value) to swap.
      */
-    function _moveFees(address from, address gasToken, uint256 gasFee) internal {
-        address _vaultPC = address(VAULT_PC);
-        if (_vaultPC == address(0)) revert Errors.ZeroAddress();
+    function _swapAndCollectFees(
+        address prc20,
+        uint256 pcAmount
+    ) internal returns (uint256 gasTokenOut) {
+        if (pcAmount == 0) revert Errors.ZeroAmount();
+        address vault = address(VAULT_PC);
+        if (vault == address(0)) revert Errors.ZeroAddress();
 
-        bool ok = IPRC20(gasToken).transferFrom(from, _vaultPC, gasFee);
-        if (!ok) revert Errors.GasFeeTransferFailed(gasToken, from, gasFee);
+        gasTokenOut = IUniversalCore(UNIVERSAL_CORE)
+            .swapPCForGasToken{value: pcAmount}(
+                prc20, vault, 0, 0, 0
+            );
     }
 
     function _burnPRC20(address from, address token, uint256 amount) internal {

--- a/contracts/evm-gateway/src/UniversalGatewayPC.sol
+++ b/contracts/evm-gateway/src/UniversalGatewayPC.sol
@@ -92,8 +92,14 @@ contract UniversalGatewayPC is
 
         TX_TYPE txType = _fetchTxType(req);
 
-        (address gasToken, uint256 gasFee, uint256 gasLimitUsed, uint256 protocolFee, string memory chainNamespace) =
-            _fetchOutboundTxInfo(req.token, req.gasLimit);
+        (
+            address gasToken,
+            uint256 gasFee,
+            uint256 gasLimitUsed,
+            uint256 protocolFee,
+            uint256 gasPrice,
+            string memory chainNamespace
+        ) = _fetchOutboundTxInfo(req.token, req.gasLimit);
 
         if (req.amount > 0) {
             _burnPRC20(msg.sender, req.token, req.amount);
@@ -122,7 +128,7 @@ contract UniversalGatewayPC is
             protocolFee,
             req.revertRecipient,
             txType,
-            msg.value
+            gasPrice
         );
     }
 
@@ -163,6 +169,7 @@ contract UniversalGatewayPC is
      * @return gasFee       Gas cost in gas token units (excludes protocol fee).
      * @return gasLimitUsed Gas limit actually used for the quote.
      * @return protocolFee  Flat protocol fee in gas token units.
+     * @return gasPrice     Gas price on the external chain (wei per gas unit).
      * @return chainNamespace Chain namespace string for the target chain.
      */
     function _fetchOutboundTxInfo(address token, uint256 gasLimit)
@@ -173,12 +180,13 @@ contract UniversalGatewayPC is
             uint256 gasFee,
             uint256 gasLimitUsed,
             uint256 protocolFee,
+            uint256 gasPrice,
             string memory chainNamespace
         )
     {
         gasLimitUsed = gasLimit == 0 ? IUniversalCore(UNIVERSAL_CORE).BASE_GAS_LIMIT() : gasLimit;
 
-        (gasToken, gasFee, protocolFee, chainNamespace) =
+        (gasToken, gasFee, protocolFee, gasPrice, chainNamespace) =
             IUniversalCore(UNIVERSAL_CORE).getOutboundTxGasAndFees(token, gasLimitUsed);
 
         if (gasToken == address(0) || gasFee + protocolFee == 0) {

--- a/contracts/evm-gateway/src/UniversalGatewayPC.sol
+++ b/contracts/evm-gateway/src/UniversalGatewayPC.sol
@@ -213,7 +213,7 @@ contract UniversalGatewayPC is
         }
 
         (gasToken, gasFee, protocolFee, chainNamespace) =
-            IUniversalCore(UNIVERSAL_CORE).withdrawGasFeeWithGasLimit(token, gasLimitUsed);
+            IUniversalCore(UNIVERSAL_CORE).getOutboundTxGasAndFees(token, gasLimitUsed);
 
         if (gasToken == address(0) || gasFee + protocolFee == 0) {
             revert Errors.InvalidData();

--- a/contracts/evm-gateway/src/UniversalGatewayPC.sol
+++ b/contracts/evm-gateway/src/UniversalGatewayPC.sol
@@ -5,17 +5,10 @@ pragma solidity 0.8.26;
  * @title   UniversalGatewayPC
  * @notice  Outbound gateway on Push Chain for bridging funds and payloads to external EVM chains.
  *
- * @dev
- *         - Strictly to be deployed on Push Chain.
- *         - Allows users to withdraw PRC20 (wrapped) tokens back to the origin chain.
- *         - Allows users to withdraw PRC20 and attach a payload for arbitrary call execution on the origin chain.
- *         - Allows payload-only transactions (no token burn) using existing CEA funds on the origin chain.
- *         - This contract does NOT handle deposits or inbound transfers.
- *         - This contract does NOT custody user assets; PRC20 are burned at request time.
- *         - Gas fees are paid in native PC, swapped to gas token PRC20 via UniversalCore.
- *           The gas cost portion (gasFee) is burned by UniversalCore, freeing backing tokens for TSS relayers.
- *           The protocol fee portion (protocolFee) is sent to VaultPC as revenue.
- *           Unused PC is refunded directly to the caller by UniversalCore.
+ * @dev     Deployed on Push Chain only. Routes three outbound TX_TYPEs: FUNDS, FUNDS_AND_PAYLOAD,
+ *          and GAS_AND_PAYLOAD. PRC20 tokens are burned at request time; gas fees paid in native PC
+ *          are swapped via UniversalCore — the gas-cost portion is burned (freeing backing tokens
+ *          for TSS relayers) and the protocol-fee portion is sent to VaultPC as revenue.
  */
 import { Errors } from "./libraries/Errors.sol";
 import { IPRC20 } from "./interfaces/IPRC20.sol";
@@ -36,23 +29,20 @@ contract UniversalGatewayPC is
     PausableUpgradeable,
     IUniversalGatewayPC
 {
-    /// @notice Pauser role for pausing the contract.
     bytes32 public constant PAUSER_ROLE = keccak256("PAUSER_ROLE");
 
-    /// @notice UniversalCore on Push Chain (provides gas coin/prices + UEM address).
     address public UNIVERSAL_CORE;
-
-    /// @notice VaultPC on Push Chain (custody vault for fees collected from outbound flows).
     IVaultPC public VAULT_PC;
-
-    /// @notice Nonce for outbound transactions.
     uint256 public nonce;
 
-    /// @notice                 Initializes the contract.
-    /// @param admin            address of the admin.
-    /// @param pauser           address of the pauser.
-    /// @param universalCore    address of the UniversalCore.
-    /// @param vaultPC          address of the VaultPC.
+    // =========================
+    //  UGPC_1: ADMIN ACTIONS
+    // =========================
+
+    /// @param admin            Address of the admin.
+    /// @param pauser           Address of the pauser.
+    /// @param universalCore    Address of the UniversalCore.
+    /// @param vaultPC          Address of the VaultPC.
     function initialize(address admin, address pauser, address universalCore, address vaultPC) external initializer {
         if (admin == address(0) || pauser == address(0) || universalCore == address(0) || vaultPC == address(0)) {
             revert Errors.ZeroAddress();
@@ -69,15 +59,6 @@ contract UniversalGatewayPC is
         VAULT_PC = IVaultPC(vaultPC);
     }
 
-    /// @notice                 Sets the VaultPC address.
-    /// @param vaultPC    address of the VaultPC.
-    function setVaultPC(address vaultPC) external onlyRole(DEFAULT_ADMIN_ROLE) whenNotPaused {
-        if (vaultPC == address(0)) revert Errors.ZeroAddress();
-        address oldVaultPC = address(VAULT_PC);
-        VAULT_PC = IVaultPC(vaultPC);
-        emit VaultPCUpdated(oldVaultPC, vaultPC);
-    }
-
     function pause() external onlyRole(PAUSER_ROLE) whenNotPaused {
         _pause();
     }
@@ -86,10 +67,20 @@ contract UniversalGatewayPC is
         _unpause();
     }
 
+    /// @notice Sets the VaultPC address.
+    /// @param vaultPC Address of the new VaultPC.
+    function setVaultPC(address vaultPC) external onlyRole(DEFAULT_ADMIN_ROLE) whenNotPaused {
+        if (vaultPC == address(0)) revert Errors.ZeroAddress();
+        address oldVaultPC = address(VAULT_PC);
+        VAULT_PC = IVaultPC(vaultPC);
+        emit VaultPCUpdated(oldVaultPC, vaultPC);
+    }
+
+    // =========================
+    //  UGPC_2: OUTBOUND TX
+    // =========================
+
     /// @notice Sends an outbound universal transaction from Push Chain to an external chain.
-    /// @dev    Infers TX_TYPE from the request, quotes gas fees, burns PRC20 (if amount > 0),
-    ///         swaps native PC to gas token PRC20 via UniversalCore exactOutputSingle (refunding
-    ///         unused PC directly to the caller), and emits UniversalTxOutbound.
     /// @param req The outbound transaction request struct.
     function sendUniversalTxOutbound(UniversalOutboundTxRequest calldata req)
         external
@@ -99,19 +90,15 @@ contract UniversalGatewayPC is
     {
         _validateCommon(req.token, req.revertRecipient);
 
-        // Determine TX_TYPE based on user input (rejects empty transactions internally)
         TX_TYPE txType = _fetchTxType(req);
 
-        // Quote gas fees and chain metadata from UniversalCore
         (address gasToken, uint256 gasFee, uint256 gasLimitUsed, uint256 protocolFee, string memory chainNamespace) =
             _fetchOutboundTxInfo(req.token, req.gasLimit);
 
-        // Burn PRC20 first (if amount > 0), before swap
         if (req.amount > 0) {
             _burnPRC20(msg.sender, req.token, req.amount);
         }
 
-        // Swap native PC → gas token: burns gasFee and sends protocolFee to VaultPC
         _swapAndCollectFees(gasToken, msg.value, gasFee, protocolFee);
 
         uint256 _nonce = nonce;
@@ -139,46 +126,29 @@ contract UniversalGatewayPC is
         );
     }
 
-    // ========= Helpers =========
+    // =========================
+    //  UGPC_3: INTERNAL HELPERS
+    // =========================
 
     /**
-     * @notice                  Infers the TX_TYPE for an outbound universal request from Push Chain.
-     * @dev                     Determines TX_TYPE based on the presence of payload and amount:
-     *                          - If NO payload AND funds > 0: TX_TYPE.FUNDS (funds-only withdrawal)
-     *                          - If payload AND amount > 0: TX_TYPE.FUNDS_AND_PAYLOAD (funds + execution)
-     *                          - If payload AND amount == 0: TX_TYPE.GAS_AND_PAYLOAD (execution-only)
-     *                          - If NO payload AND NO funds: Reverts with InvalidInput (empty transaction)
-     * @param req               UniversalOutboundTxRequest struct
-     * @return inferred         The inferred TX_TYPE for routing
+     * @notice Infers TX_TYPE from the outbound request.
+     * @dev    - amount > 0, no payload  → FUNDS
+     *         - amount > 0, payload     → FUNDS_AND_PAYLOAD
+     *         - amount = 0, payload     → GAS_AND_PAYLOAD
+     *         - amount = 0, no payload  → reverts (empty tx)
      */
     function _fetchTxType(UniversalOutboundTxRequest calldata req) private pure returns (TX_TYPE inferred) {
         bool hasPayload = req.payload.length > 0;
         bool hasFunds = req.amount > 0;
 
-        // Case 1: No payload + Funds → FUNDS (funds-only withdrawal)
-        if (!hasPayload && hasFunds) {
-            return TX_TYPE.FUNDS;
-        }
+        if (!hasPayload && hasFunds) return TX_TYPE.FUNDS;
+        if (hasPayload && hasFunds) return TX_TYPE.FUNDS_AND_PAYLOAD;
+        if (hasPayload && !hasFunds) return TX_TYPE.GAS_AND_PAYLOAD;
 
-        // Case 2: Payload + Funds → FUNDS_AND_PAYLOAD (funds + execution)
-        if (hasPayload && hasFunds) {
-            return TX_TYPE.FUNDS_AND_PAYLOAD;
-        }
-
-        // Case 3: Payload only (no funds) → GAS_AND_PAYLOAD (execution-only)
-        if (hasPayload && !hasFunds) {
-            return TX_TYPE.GAS_AND_PAYLOAD;
-        }
-
-        // Case 4: No payload + No funds → Invalid (empty transaction)
         revert Errors.InvalidInput();
     }
 
-    /// @notice                 Validates the common parameters.
-    /// @dev                    Validates token and revertRecipient addresses.
-    ///                         Amount validation is handled in _fetchTxType() to support payload-only transactions.
-    /// @param token            PRC20 token address on Push Chain.
-    /// @param revertRecipient  address to receive funds in case of revert.
+    /// @dev Validates token and revertRecipient are non-zero.
     function _validateCommon(address token, address revertRecipient) internal pure {
         if (token == address(0)) revert Errors.ZeroAddress();
         if (revertRecipient == address(0)) revert Errors.InvalidRecipient();
@@ -187,9 +157,9 @@ contract UniversalGatewayPC is
     /**
      * @dev    Fetch gas fee quote and chain metadata from UniversalCore.
      *         If gasLimit = 0, uses BASE_GAS_LIMIT from UniversalCore.
-     * @param token         PRC20 token address on Push Chain (used by UniversalCore to resolve chain).
+     * @param token         PRC20 token address (used to resolve chain).
      * @param gasLimit      Caller-requested gas limit (0 = default).
-     * @return gasToken     PRC20 address of the gas token for the target chain.
+     * @return gasToken     Gas token PRC20 address for the target chain.
      * @return gasFee       Gas cost in gas token units (excludes protocol fee).
      * @return gasLimitUsed Gas limit actually used for the quote.
      * @return protocolFee  Flat protocol fee in gas token units.
@@ -206,11 +176,7 @@ contract UniversalGatewayPC is
             string memory chainNamespace
         )
     {
-        if (gasLimit == 0) {
-            gasLimitUsed = IUniversalCore(UNIVERSAL_CORE).BASE_GAS_LIMIT();
-        } else {
-            gasLimitUsed = gasLimit;
-        }
+        gasLimitUsed = gasLimit == 0 ? IUniversalCore(UNIVERSAL_CORE).BASE_GAS_LIMIT() : gasLimit;
 
         (gasToken, gasFee, protocolFee, chainNamespace) =
             IUniversalCore(UNIVERSAL_CORE).getOutboundTxGasAndFees(token, gasLimitUsed);
@@ -221,8 +187,8 @@ contract UniversalGatewayPC is
     }
 
     /**
-     * @dev     Swap native PC → gas token PRC20 via UniversalCore. Burns gasFee, sends protocolFee to VaultPC.
-     *          UniversalCore refunds any unused PC directly to the caller.
+     * @dev    Swap native PC → gas token PRC20 via UniversalCore.
+     *         Burns gasFee, sends protocolFee to VaultPC. Refunds unused PC to caller.
      * @param gasToken     Gas token PRC20 address (e.g., pETH).
      * @param pcAmount     Native PC amount (msg.value) to swap.
      * @param gasFee       Gas cost portion to burn (in gas token units).
@@ -233,17 +199,14 @@ contract UniversalGatewayPC is
         address vault = address(VAULT_PC);
         if (vault == address(0)) revert Errors.ZeroAddress();
 
-        IUniversalCore(UNIVERSAL_CORE).swapAndBurnGas{ value: pcAmount }(
+        IUniversalCore(UNIVERSAL_CORE).swapAndBurnGas{value: pcAmount}(
             gasToken, vault, 0, gasFee, protocolFee, 0, msg.sender
         );
     }
 
     /// @dev Pulls PRC20 from `from` into this contract, then burns them.
     function _burnPRC20(address from, address token, uint256 amount) internal {
-        // Pull PRC20 into this gateway first
         IPRC20(token).transferFrom(from, address(this), amount);
-
-        // Then burn from this contract's balance
         bool ok = IPRC20(token).burn(amount);
         if (!ok) revert Errors.TokenBurnFailed(token, amount);
     }

--- a/contracts/evm-gateway/src/UniversalGatewayPC.sol
+++ b/contracts/evm-gateway/src/UniversalGatewayPC.sol
@@ -12,8 +12,10 @@ pragma solidity 0.8.26;
  *         - Allows payload-only transactions (no token burn) using existing CEA funds on the origin chain.
  *         - This contract does NOT handle deposits or inbound transfers.
  *         - This contract does NOT custody user assets; PRC20 are burned at request time.
- *         - Gas fees are paid in native PC, swapped to gas token PRC20 via UniversalCore (exactOutputSingle),
- *           and sent to VaultPC. Unused PC is refunded directly to the caller by UniversalCore.
+ *         - Gas fees are paid in native PC, swapped to gas token PRC20 via UniversalCore.
+ *           The gas cost portion (gasFee) is burned by UniversalCore, freeing backing tokens for TSS relayers.
+ *           The protocol fee portion (protocolFee) is sent to VaultPC as revenue.
+ *           Unused PC is refunded directly to the caller by UniversalCore.
  */
 import { Errors } from "./libraries/Errors.sol";
 import { IPRC20 } from "./interfaces/IPRC20.sol";
@@ -100,19 +102,17 @@ contract UniversalGatewayPC is
         // Determine TX_TYPE based on user input (rejects empty transactions internally)
         TX_TYPE txType = _fetchTxType(req);
 
-        // Quote for event data (gasToken address, gasFee, protocolFee)
-        (address gasToken, uint256 gasFee, uint256 gasLimitUsed, uint256 protocolFee) =
-            _calculateGasFeesWithLimit(req.token, req.gasLimit);
+        // Quote gas fees and chain metadata from UniversalCore
+        (address gasToken, uint256 gasFee, uint256 gasLimitUsed, uint256 protocolFee, string memory chainNamespace) =
+            _fetchOutboundTxInfo(req.token, req.gasLimit);
 
         // Burn PRC20 first (if amount > 0), before swap
         if (req.amount > 0) {
             _burnPRC20(msg.sender, req.token, req.amount);
         }
 
-        // Swap native PC → gas token PRC20 → VaultPC (exactOutputSingle: reverts if insufficient)
-        _swapAndCollectFees(req.token, msg.value, gasFee);
-
-        string memory chainNamespace = IPRC20(req.token).SOURCE_CHAIN_NAMESPACE();
+        // Swap native PC → gas token: burns gasFee and sends protocolFee to VaultPC
+        _swapAndCollectFees(gasToken, msg.value, gasFee, protocolFee);
 
         uint256 _nonce = nonce;
         nonce = _nonce + 1;
@@ -185,19 +185,26 @@ contract UniversalGatewayPC is
     }
 
     /**
-     * @dev                 Use UniversalCore's withdrawGasFeeWithGasLimit to compute fee (gas coin + amount).
-     *                      If gasLimit = 0, pull the default BASE_GAS_LIMIT from UniversalCore.
-     * @param token         PRC20 token address on Push Chain (used to resolve chain namespace and protocol fee).
-     * @param gasLimit      Caller-requested gas limit (0 = use BASE_GAS_LIMIT from UniversalCore).
+     * @dev    Fetch gas fee quote and chain metadata from UniversalCore.
+     *         If gasLimit = 0, uses BASE_GAS_LIMIT from UniversalCore.
+     * @param token         PRC20 token address on Push Chain (used by UniversalCore to resolve chain).
+     * @param gasLimit      Caller-requested gas limit (0 = default).
      * @return gasToken     PRC20 address of the gas token for the target chain.
-     * @return gasFee       Amount of gasToken to collect (includes protocol fee).
+     * @return gasFee       Gas cost in gas token units (excludes protocol fee).
      * @return gasLimitUsed Gas limit actually used for the quote.
-     * @return protocolFee  Flat protocol fee component (as exposed by PRC20).
+     * @return protocolFee  Flat protocol fee in gas token units.
+     * @return chainNamespace Chain namespace string for the target chain.
      */
-    function _calculateGasFeesWithLimit(address token, uint256 gasLimit)
+    function _fetchOutboundTxInfo(address token, uint256 gasLimit)
         internal
         view
-        returns (address gasToken, uint256 gasFee, uint256 gasLimitUsed, uint256 protocolFee)
+        returns (
+            address gasToken,
+            uint256 gasFee,
+            uint256 gasLimitUsed,
+            uint256 protocolFee,
+            string memory chainNamespace
+        )
     {
         if (gasLimit == 0) {
             gasLimitUsed = IUniversalCore(UNIVERSAL_CORE).BASE_GAS_LIMIT();
@@ -205,25 +212,30 @@ contract UniversalGatewayPC is
             gasLimitUsed = gasLimit;
         }
 
-        (gasToken, gasFee) = IUniversalCore(UNIVERSAL_CORE).withdrawGasFeeWithGasLimit(token, gasLimitUsed);
-        if (gasToken == address(0) || gasFee == 0) revert Errors.InvalidData();
+        (gasToken, gasFee, protocolFee, chainNamespace) =
+            IUniversalCore(UNIVERSAL_CORE).withdrawGasFeeWithGasLimit(token, gasLimitUsed);
 
-        protocolFee = IPRC20(token).PC_PROTOCOL_FEE();
+        if (gasToken == address(0) || gasFee + protocolFee == 0) {
+            revert Errors.InvalidData();
+        }
     }
 
     /**
-     * @dev     Swap native PC → gas token PRC20 via UniversalCore (exactOutputSingle), sending output to VaultPC.
+     * @dev     Swap native PC → gas token PRC20 via UniversalCore. Burns gasFee, sends protocolFee to VaultPC.
      *          UniversalCore refunds any unused PC directly to the caller.
-     * @param prc20    PRC20 token address (used by UniversalCore to resolve the swap pair).
-     * @param pcAmount Native PC amount (msg.value) to swap.
-     * @param gasFee   Exact gas token output required (passed as requiredGasTokenOut).
+     * @param gasToken     Gas token PRC20 address (e.g., pETH).
+     * @param pcAmount     Native PC amount (msg.value) to swap.
+     * @param gasFee       Gas cost portion to burn (in gas token units).
+     * @param protocolFee  Protocol fee portion to send to VaultPC (in gas token units).
      */
-    function _swapAndCollectFees(address prc20, uint256 pcAmount, uint256 gasFee) internal {
+    function _swapAndCollectFees(address gasToken, uint256 pcAmount, uint256 gasFee, uint256 protocolFee) internal {
         if (pcAmount == 0) revert Errors.ZeroAmount();
         address vault = address(VAULT_PC);
         if (vault == address(0)) revert Errors.ZeroAddress();
 
-        IUniversalCore(UNIVERSAL_CORE).swapPCForGasToken{ value: pcAmount }(prc20, vault, 0, gasFee, 0, msg.sender);
+        IUniversalCore(UNIVERSAL_CORE).swapAndBurnGas{ value: pcAmount }(
+            gasToken, vault, 0, gasFee, protocolFee, 0, msg.sender
+        );
     }
 
     /// @dev Pulls PRC20 from `from` into this contract, then burns them.

--- a/contracts/evm-gateway/src/UniversalGatewayPC.sol
+++ b/contracts/evm-gateway/src/UniversalGatewayPC.sol
@@ -88,7 +88,7 @@ contract UniversalGatewayPC is
         whenNotPaused
         nonReentrant
     {
-        _validateCommon(req.token, req.revertRecipient);
+        _validateParams(req.token, req.revertRecipient);
 
         TX_TYPE txType = _fetchTxType(req);
 
@@ -149,7 +149,7 @@ contract UniversalGatewayPC is
     }
 
     /// @dev Validates token and revertRecipient are non-zero.
-    function _validateCommon(address token, address revertRecipient) internal pure {
+    function _validateParams(address token, address revertRecipient) internal pure {
         if (token == address(0)) revert Errors.ZeroAddress();
         if (revertRecipient == address(0)) revert Errors.InvalidRecipient();
     }
@@ -199,7 +199,7 @@ contract UniversalGatewayPC is
         address vault = address(VAULT_PC);
         if (vault == address(0)) revert Errors.ZeroAddress();
 
-        IUniversalCore(UNIVERSAL_CORE).swapAndBurnGas{value: pcAmount}(
+        IUniversalCore(UNIVERSAL_CORE).swapAndBurnGas{ value: pcAmount }(
             gasToken, vault, 0, gasFee, protocolFee, 0, msg.sender
         );
     }

--- a/contracts/evm-gateway/src/UniversalGatewayV0.sol
+++ b/contracts/evm-gateway/src/UniversalGatewayV0.sol
@@ -399,7 +399,7 @@ contract UniversalGatewayV0 is
         if (!ICEAFactory(ceaFactory).isCEA(msg.sender)) revert Errors.Unauthorized();
 
         // Resolve the UEA mapped to this CEA and enforce anti-spoof
-        address mappedUEA = ICEAFactory(ceaFactory).getUEAForCEA(msg.sender);
+        address mappedUEA = ICEAFactory(ceaFactory).getPushAccountForCEA(msg.sender);
         if (req.recipient != mappedUEA) revert Errors.InvalidInput();
 
         uint256 nativeValue = msg.value;
@@ -1041,10 +1041,7 @@ contract UniversalGatewayV0 is
     /// @param nativeValue      Raw native value received with the transaction
     /// @return adjustedNative  nativeValue minus the collected fee
     /// @return feeCollected    Amount forwarded to TSS as the protocol fee
-    function _collectProtocolFee(uint256 nativeValue)
-        private
-        returns (uint256 adjustedNative, uint256 feeCollected)
-    {
+    function _collectProtocolFee(uint256 nativeValue) private returns (uint256 adjustedNative, uint256 feeCollected) {
         uint256 fee = PROTOCOL_FEE;
         if (fee == 0) return (nativeValue, 0);
 

--- a/contracts/evm-gateway/src/Vault.sol
+++ b/contracts/evm-gateway/src/Vault.sol
@@ -36,27 +36,17 @@ contract Vault is
 {
     using SafeERC20 for IERC20;
 
-    // =========================
-    //            ROLES
-    // =========================
     bytes32 public constant TSS_ROLE = keccak256("TSS_ROLE");
     bytes32 public constant PAUSER_ROLE = keccak256("PAUSER_ROLE");
 
-    // =========================
-    //           STATE
-    // =========================
-    /// @notice UniversalGateway on the same chain; source of truth for token support.
     IUniversalGateway public gateway;
-
-    /// @notice The current TSS address for Vault
     address public TSS_ADDRESS;
-
-    /// @notice The current CEAFactory address for Vault
     ICEAFactory public CEAFactory;
 
-    // =========================
-    //         INITIALIZER
-    // =========================
+    // ==============================
+    //  VAULT_1: ADMIN ACTIONS
+    // ==============================
+
     function initialize(address admin, address pauser, address tss, address gw, address ceaFactory)
         external
         initializer
@@ -82,24 +72,16 @@ contract Vault is
         CEAFactory = ICEAFactory(ceaFactory);
     }
 
-    // =========================
-    //          ADMIN OPS
-    // =========================
-    /// @notice             Allows the admin to pause the contract
-    /// @dev                Only callable by PAUSER_ROLE
     function pause() external whenNotPaused onlyRole(PAUSER_ROLE) {
         _pause();
     }
 
-    /// @notice             Allows the admin to unpause the contract
-    /// @dev                Only callable by PAUSER_ROLE
     function unpause() external whenPaused onlyRole(PAUSER_ROLE) {
         _unpause();
     }
 
-    /// @notice             Allows the admin to update the UniversalGateway address
-    /// @dev                Only callable by DEFAULT_ADMIN_ROLE
-    /// @param gw           New UniversalGateway address
+    /// @notice Updates the UniversalGateway address.
+    /// @param gw New UniversalGateway address.
     function setGateway(address gw) external onlyRole(DEFAULT_ADMIN_ROLE) {
         if (gw == address(0)) revert Errors.ZeroAddress();
         address old = address(gateway);
@@ -107,9 +89,8 @@ contract Vault is
         emit GatewayUpdated(old, gw);
     }
 
-    /// @notice             Allows the admin to update the TSS address
-    /// @dev                Only callable by DEFAULT_ADMIN_ROLE
-    /// @param newTss       New TSS address
+    /// @notice Updates the TSS address and transfers TSS_ROLE.
+    /// @param newTss New TSS address.
     function setTSS(address newTss) external onlyRole(DEFAULT_ADMIN_ROLE) {
         if (newTss == address(0)) revert Errors.ZeroAddress();
         address old = TSS_ADDRESS;
@@ -122,9 +103,8 @@ contract Vault is
         emit TSSUpdated(old, newTss);
     }
 
-    /// @notice             Allows the admin to update the CEAFactory address
-    /// @dev                Only callable by DEFAULT_ADMIN_ROLE
-    /// @param newCEAFactory New CEAFactory address
+    /// @notice Updates the CEAFactory address.
+    /// @param newCEAFactory New CEAFactory address.
     function setCEAFactory(address newCEAFactory) external onlyRole(DEFAULT_ADMIN_ROLE) {
         if (newCEAFactory == address(0)) revert Errors.ZeroAddress();
         address old = address(CEAFactory);
@@ -132,21 +112,17 @@ contract Vault is
         emit CEAFactoryUpdated(old, newCEAFactory);
     }
 
-    /// @notice             Allows the admin to sweep tokens from the contract
-    /// @dev                Only callable by DEFAULT_ADMIN_ROLE
-    /// @param token        Token address
-    /// @param to           Recipient address
-    /// @param amount       Amount of token to sweep
+    /// @notice Sweeps stuck ERC20 tokens from the contract.
     function sweep(address token, address to, uint256 amount) external onlyRole(DEFAULT_ADMIN_ROLE) {
         if (token == address(0) || to == address(0)) revert Errors.ZeroAddress();
         IERC20(token).safeTransfer(to, amount);
     }
 
-    // =========================
-    //   WITHDRAW & EXECUTION
-    // =========================
+    // ==============================
+    //  VAULT_2: WITHDRAW & EXECUTION
+    // ==============================
+
     /// @inheritdoc IVault
-    /// @dev All execution now routes through CEA.executeUniversalTx with multicall payload
     function finalizeUniversalTx(
         bytes32 subTxId,
         bytes32 universalTxId,
@@ -165,7 +141,6 @@ contract Vault is
         // Single execution path for all operations
         _finalizeUniversalTx(subTxId, universalTxId, pushAccount, recipient, token, amount, data, cea);
 
-        // Emit event
         emit VaultUniversalTxFinalized(subTxId, universalTxId, pushAccount, recipient, token, amount, data);
     }
 
@@ -190,9 +165,10 @@ contract Vault is
         emit VaultUniversalTxReverted(subTxId, universalTxId, token, amount, revertInstruction);
     }
 
-    // =========================
-    //        INTERNALS
-    // =========================
+    // ==============================
+    //  VAULT_3: INTERNAL HELPERS
+    // ==============================
+
     function _enforceSupported(address token) internal view {
         // Single source of truth lives in UniversalGateway
         if (!gateway.isSupportedToken(token)) revert Errors.NotSupported();
@@ -234,10 +210,8 @@ contract Vault is
         bytes calldata data,
         address cea
     ) private {
-        // Validations
         _validateParams(pushAccount, token, amount);
 
-        // Fund CEA and forward multicall payload
         if (token != address(0)) {
             // ERC20: transfer to CEA first, then execute multicall
             if (IERC20(token).balanceOf(address(this)) < amount) revert Errors.InvalidAmount();

--- a/contracts/evm-gateway/src/VaultPC.sol
+++ b/contracts/evm-gateway/src/VaultPC.sol
@@ -6,8 +6,8 @@ pragma solidity 0.8.26;
  * @notice  Custody vault to store fees collected from outbound flows on Push Chain.
  * @dev    - TransparentUpgradeable (OZ Initializable pattern)
  *         - Only supports PRC20 tokens.
- *         - Funds stored are managed by the FUND_MANAGER_ROLE.
- *         - All fees earned via outbound flows are stored and handled in this contract by FUND_MANAGER_ROLE.
+ *         - Funds stored are managed by the MANAGER_ROLE.
+ *         - All fees earned via outbound flows are stored and handled in this contract by MANAGER_ROLE.
  */
 
 import {Errors}                     from "./libraries/Errors.sol";
@@ -33,15 +33,17 @@ contract VaultPC is
     using SafeERC20 for IERC20;
 
     bytes32 public constant PAUSER_ROLE = keccak256("PAUSER_ROLE");
-    bytes32 public constant FUND_MANAGER_ROLE = keccak256("FUND_MANAGER_ROLE");
+    bytes32 public constant MANAGER_ROLE = keccak256("MANAGER_ROLE");
 
-    /**
-     * @param admin   DEFAULT_ADMIN_ROLE holder
-     * @param pauser  PAUSER_ROLE
-     * @param fundManager  FUND_MANAGER_ROLE
-     */
-    function initialize(address admin, address pauser, address fundManager) external initializer {
-        if (admin == address(0) || pauser == address(0) || fundManager == address(0)) revert Errors.ZeroAddress();
+    // ==============================
+    //  VAULT_PC_1: ADMIN ACTIONS
+    // ==============================
+
+    /// @param admin       DEFAULT_ADMIN_ROLE holder.
+    /// @param pauser      PAUSER_ROLE holder.
+    /// @param manager     MANAGER_ROLE holder.
+    function initialize(address admin, address pauser, address manager) external initializer {
+        if (admin == address(0) || pauser == address(0) || manager == address(0)) revert Errors.ZeroAddress();
 
         __Context_init();
         __Pausable_init();
@@ -49,31 +51,28 @@ contract VaultPC is
         __AccessControl_init();
 
         _grantRole(DEFAULT_ADMIN_ROLE, admin);
-        _grantRole(PAUSER_ROLE,          pauser);
-        _grantRole(FUND_MANAGER_ROLE,    fundManager);
-
+        _grantRole(PAUSER_ROLE, pauser);
+        _grantRole(MANAGER_ROLE, manager);
     }
 
-    // =========================
-    //          ADMIN OPS
-    // =========================
     function pause() external whenNotPaused onlyRole(PAUSER_ROLE) {
         _pause();
     }
+
     function unpause() external whenPaused onlyRole(PAUSER_ROLE) {
         _unpause();
     }
 
-    // =========================
-    //          WITHDRAW
-    // =========================
-    
+    // ==============================
+    //  VAULT_PC_2: WITHDRAW
+    // ==============================
+
     /// @inheritdoc IVaultPC
     function withdraw(address to, uint256 amount)
         external
         nonReentrant
         whenNotPaused
-        onlyRole(FUND_MANAGER_ROLE)
+        onlyRole(MANAGER_ROLE)
     {
         if (to == address(0)) revert Errors.ZeroAddress();
         if (amount == 0) revert Errors.InvalidAmount();
@@ -90,7 +89,7 @@ contract VaultPC is
         external
         nonReentrant
         whenNotPaused
-        onlyRole(FUND_MANAGER_ROLE)
+        onlyRole(MANAGER_ROLE)
     {
         if (token == address(0) || to == address(0)) revert Errors.ZeroAddress();
         if (amount == 0) revert Errors.InvalidAmount();

--- a/contracts/evm-gateway/src/interfaces/ICEAFactory.sol
+++ b/contracts/evm-gateway/src/interfaces/ICEAFactory.sol
@@ -39,9 +39,9 @@ interface ICEAFactory {
     function isCEA(address _cea) external view returns (bool);
 
     /**
-     * @notice Returns the UEA on Push Chain that maps to the given CEA.
-     * @param _cea  CEA address on this chain.
-     * @return uea  Mapped UEA address (address(0) if no mapping exists).
+     * @notice Returns the push account (UEA) on Push Chain that maps to the given CEA.
+     * @param _cea         CEA address on this chain.
+     * @return pushAccount Mapped push account address (address(0) if no mapping exists).
      */
-    function getUEAForCEA(address _cea) external view returns (address uea);
+    function getPushAccountForCEA(address _cea) external view returns (address pushAccount);
 }

--- a/contracts/evm-gateway/src/interfaces/IPRC20.sol
+++ b/contracts/evm-gateway/src/interfaces/IPRC20.sol
@@ -14,7 +14,10 @@ interface IPRC20 {
     function SOURCE_CHAIN_NAMESPACE() external view returns (string memory);
     function PC_PROTOCOL_FEE() external view returns (uint256);
     function GAS_LIMIT() external view returns (uint256);
-    function withdrawGasFeeWithGasLimit(uint256 gasLimit) external view returns (address gasToken, uint256 gasFee);
+    function withdrawGasFeeWithGasLimit(uint256 gasLimit)
+        external
+        view
+        returns (address gasToken, uint256 gasFee, uint256 protocolFee, string memory chainNamespace);
 
     /**
      * @notice ERC-20 standard functions

--- a/contracts/evm-gateway/src/interfaces/IPRC20.sol
+++ b/contracts/evm-gateway/src/interfaces/IPRC20.sol
@@ -2,35 +2,12 @@
 pragma solidity 0.8.26;
 
 /**
- * @dev Interface for PRC20 tokens
+ * @dev Interface for PRC20 tokens — only the functions used by contracts in this repo.
  */
 interface IPRC20 {
-    /**
-     * @notice ERC-20 metadata
-     */
-    function decimals() external view returns (uint8);
-    function name() external view returns (string memory);
-    function symbol() external view returns (string memory);
     function SOURCE_CHAIN_NAMESPACE() external view returns (string memory);
     function PC_PROTOCOL_FEE() external view returns (uint256);
-    function GAS_LIMIT() external view returns (uint256);
-    function withdrawGasFeeWithGasLimit(uint256 gasLimit)
-        external
-        view
-        returns (address gasToken, uint256 gasFee, uint256 protocolFee, string memory chainNamespace);
 
-    /**
-     * @notice ERC-20 standard functions
-     */
     function burn(uint256 amount) external returns (bool);
-    function totalSupply() external view returns (uint256);
-
-    function balanceOf(address account) external view returns (uint256);
-    function deposit(address to, uint256 amount) external returns (bool);
-    
-    function approve(address spender, uint256 amount) external returns (bool);
-    function transfer(address recipient, uint256 amount) external returns (bool);
-    function allowance(address owner, address spender) external view returns (uint256);
     function transferFrom(address sender, address recipient, uint256 amount) external returns (bool);
-
 }

--- a/contracts/evm-gateway/src/interfaces/IUniversalCore.sol
+++ b/contracts/evm-gateway/src/interfaces/IUniversalCore.sol
@@ -41,9 +41,14 @@ interface IUniversalCore {
      * @dev    Uses BASE_GAS_LIMIT for the gas limit used in the fee computation.
      * @param _prc20 PRC20 address
      * @return gasToken Gas token address
-     * @return gasFee Gas fee
+     * @return gasFee Gas cost only (gasPrice * gasLimit), excludes protocol fee
+     * @return protocolFee Flat protocol fee in gas token units
+     * @return chainNamespace Chain namespace string for the target chain
      */
-    function withdrawGasFee(address _prc20) external view returns (address gasToken, uint256 gasFee);
+    function withdrawGasFee(address _prc20)
+        external
+        view
+        returns (address gasToken, uint256 gasFee, uint256 protocolFee, string memory chainNamespace);
 
     /**
      * @notice Get gas fee for a PRC20 token with a custom gas limit
@@ -51,17 +56,23 @@ interface IUniversalCore {
      * @param _prc20 PRC20 address
      * @param gasLimit Gas limit
      * @return gasToken Gas token address
-     * @return gasFee Gas fee
+     * @return gasFee Gas cost only (gasPrice * gasLimit), excludes protocol fee
+     * @return protocolFee Flat protocol fee in gas token units
+     * @return chainNamespace Chain namespace string for the target chain
      */
-    function withdrawGasFeeWithGasLimit(address _prc20, uint256 gasLimit) external view returns (address gasToken, uint256 gasFee);
+    function withdrawGasFeeWithGasLimit(address _prc20, uint256 gasLimit)
+        external
+        view
+        returns (address gasToken, uint256 gasFee, uint256 protocolFee, string memory chainNamespace);
 
     function GATEWAY_ROLE() external view returns (bytes32);
 
-    function swapPCForGasToken(
-        address prc20,
+    function swapAndBurnGas(
+        address gasToken,
         address vault,
         uint24 fee,
-        uint256 requiredGasTokenOut,
+        uint256 gasFee,
+        uint256 protocolFee,
         uint256 deadline,
         address caller
     ) external payable returns (uint256 gasTokenOut, uint256 refund);

--- a/contracts/evm-gateway/src/interfaces/IUniversalCore.sol
+++ b/contracts/evm-gateway/src/interfaces/IUniversalCore.sol
@@ -2,28 +2,6 @@
 pragma solidity 0.8.26;
 
 interface IUniversalCore {
-
-    /**
-     * @notice Check if a token is supported
-     * @param token Token address
-     * @return bool True if the token is supported, false otherwise
-     */
-    function isSupportedToken(address token) external view returns (bool);
-
-    /**
-     * @notice Get gas token PRC20 address for a chain
-     * @param chainId Chain ID
-     * @return gasToken Gas token address
-     */
-    function gasTokenPRC20ByChainNamespace(string memory chainId) external view returns (address gasToken);
-
-    /**
-     * @notice Get gas price for a chain
-     * @param chainId Chain ID
-     * @return price Gas price
-     */
-    function gasPriceByChainNamespace(string memory chainId) external view returns (uint256 price);
-
     /**
      * @notice Get base gas limit for a chain
      * @return baseGasLimit Base gas limit
@@ -31,41 +9,18 @@ interface IUniversalCore {
     function BASE_GAS_LIMIT() external view returns (uint256 baseGasLimit);
 
     /**
-     * @notice Get the Universal Executor Module address
-     * @return executorModule Universal Executor Module address
-     */
-    function UNIVERSAL_EXECUTOR_MODULE() external view returns (address executorModule);
-
-    /**
-     * @notice Get gas fee for a PRC20 token.
-     * @dev    Uses BASE_GAS_LIMIT for the gas limit used in the fee computation.
-     * @param _prc20 PRC20 address
-     * @return gasToken Gas token address
-     * @return gasFee Gas cost only (gasPrice * gasLimit), excludes protocol fee
-     * @return protocolFee Flat protocol fee in gas token units
-     * @return chainNamespace Chain namespace string for the target chain
-     */
-    function withdrawGasFee(address _prc20)
-        external
-        view
-        returns (address gasToken, uint256 gasFee, uint256 protocolFee, string memory chainNamespace);
-
-    /**
-     * @notice Get gas fee for a PRC20 token with a custom gas limit
-     * @dev    Uses the provided gas limit for the fee computation.
-     * @param _prc20 PRC20 address
+     * @notice Get gas fee and chain metadata for an outbound transaction with a custom gas limit.
+     * @param _prc20 PRC20 address (used to resolve chain namespace)
      * @param gasLimit Gas limit
      * @return gasToken Gas token address
      * @return gasFee Gas cost only (gasPrice * gasLimit), excludes protocol fee
      * @return protocolFee Flat protocol fee in gas token units
      * @return chainNamespace Chain namespace string for the target chain
      */
-    function withdrawGasFeeWithGasLimit(address _prc20, uint256 gasLimit)
+    function getOutboundTxGasAndFees(address _prc20, uint256 gasLimit)
         external
         view
         returns (address gasToken, uint256 gasFee, uint256 protocolFee, string memory chainNamespace);
-
-    function GATEWAY_ROLE() external view returns (bytes32);
 
     function swapAndBurnGas(
         address gasToken,

--- a/contracts/evm-gateway/src/interfaces/IUniversalCore.sol
+++ b/contracts/evm-gateway/src/interfaces/IUniversalCore.sol
@@ -61,7 +61,8 @@ interface IUniversalCore {
         address prc20,
         address vault,
         uint24 fee,
-        uint256 minGasTokenOut,
-        uint256 deadline
-    ) external payable returns (uint256 gasTokenOut);
+        uint256 requiredGasTokenOut,
+        uint256 deadline,
+        address caller
+    ) external payable returns (uint256 gasTokenOut, uint256 refund);
 }

--- a/contracts/evm-gateway/src/interfaces/IUniversalCore.sol
+++ b/contracts/evm-gateway/src/interfaces/IUniversalCore.sol
@@ -54,4 +54,14 @@ interface IUniversalCore {
      * @return gasFee Gas fee
      */
     function withdrawGasFeeWithGasLimit(address _prc20, uint256 gasLimit) external view returns (address gasToken, uint256 gasFee);
+
+    function GATEWAY_ROLE() external view returns (bytes32);
+
+    function swapPCForGasToken(
+        address prc20,
+        address vault,
+        uint24 fee,
+        uint256 minGasTokenOut,
+        uint256 deadline
+    ) external payable returns (uint256 gasTokenOut);
 }

--- a/contracts/evm-gateway/src/interfaces/IUniversalCore.sol
+++ b/contracts/evm-gateway/src/interfaces/IUniversalCore.sol
@@ -9,18 +9,20 @@ interface IUniversalCore {
     function BASE_GAS_LIMIT() external view returns (uint256 baseGasLimit);
 
     /**
-     * @notice Get gas fee and chain metadata for an outbound transaction with a custom gas limit.
-     * @param _prc20 PRC20 address (used to resolve chain namespace)
-     * @param gasLimit Gas limit
+     * @notice Get gas fee for a PRC20 token, split into gasFee and protocolFee.
+     * @dev    When gasLimit is 0, falls back to BASE_GAS_LIMIT.
+     * @param _prc20 PRC20 address
+     * @param gasLimit Gas limit (0 = use BASE_GAS_LIMIT)
      * @return gasToken Gas token address
-     * @return gasFee Gas cost only (gasPrice * gasLimit), excludes protocol fee
-     * @return protocolFee Flat protocol fee in gas token units
-     * @return chainNamespace Chain namespace string for the target chain
+     * @return gasFee Gas fee (gasPrice * effective gas limit)
+     * @return protocolFee Protocol fee from PRC20
+     * @return gasPrice Gas price on the external chain
+     * @return chainNamespace Source chain namespace
      */
     function getOutboundTxGasAndFees(address _prc20, uint256 gasLimit)
         external
         view
-        returns (address gasToken, uint256 gasFee, uint256 protocolFee, string memory chainNamespace);
+        returns (address gasToken, uint256 gasFee, uint256 protocolFee, uint256 gasPrice, string memory chainNamespace);
 
     function swapAndBurnGas(
         address gasToken,

--- a/contracts/evm-gateway/src/interfaces/IUniversalGateway.sol
+++ b/contracts/evm-gateway/src/interfaces/IUniversalGateway.sol
@@ -191,7 +191,7 @@ interface IUniversalGateway {
      *                         Strict validations:
      *                         - msg.sender must be a valid CEA per CEAFactory.isCEA()
      *                         - req.recipient must exactly match the mapped UEA from
-     *                           CEAFactory.getUEAForCEA() (anti-spoof).
+     *                           CEAFactory.getPushAccountForCEA() (anti-spoof).
      *
      * @param req              UniversalTxRequest struct
      */

--- a/contracts/evm-gateway/src/interfaces/IUniversalGatewayPC.sol
+++ b/contracts/evm-gateway/src/interfaces/IUniversalGatewayPC.sol
@@ -36,7 +36,8 @@ interface IUniversalGatewayPC {
         bytes payload,
         uint256 protocolFee,
         address revertRecipient,
-        TX_TYPE txType
+        TX_TYPE txType,
+        uint256 gasPrice
     );
 
     /// @notice                 Emitted when VaultPC address is updated
@@ -49,7 +50,7 @@ interface IUniversalGatewayPC {
      *                           TX_TYPE is automatically inferred based on the presence of payload and amount.
      * @param req                UniversalOutboundTxRequest struct containing all transaction parameters.
      */
-    function sendUniversalTxOutbound(UniversalOutboundTxRequest calldata req) external;
+    function sendUniversalTxOutbound(UniversalOutboundTxRequest calldata req) external payable;
 
     // ========= View Functions =========
     function UNIVERSAL_CORE() external view returns (address);

--- a/contracts/evm-gateway/src/interfaces/IVaultPC.sol
+++ b/contracts/evm-gateway/src/interfaces/IVaultPC.sol
@@ -19,7 +19,7 @@ interface IVaultPC {
 
     /**
      * @notice          Emitted when fees are withdrawn from the vault
-     * @param caller    The address that initiated the withdrawal (FUND_MANAGER_ROLE)
+     * @param caller    The address that initiated the withdrawal (MANAGER_ROLE)
      * @param token     The PRC20 token address (address(0) for native PC)
      * @param amount    The amount withdrawn
      */
@@ -30,16 +30,16 @@ interface IVaultPC {
     // =========================
     
     /**
-     * @notice          Allows FUND_MANAGER_ROLE to withdraw native PC tokens from the vault
-     * @dev             Only callable by FUND_MANAGER_ROLE
+     * @notice          Allows MANAGER_ROLE to withdraw native PC tokens from the vault
+     * @dev             Only callable by MANAGER_ROLE
      * @param to        Recipient address
      * @param amount    Amount of native PC to transfer
      */
     function withdraw(address to, uint256 amount) external;
 
     /**
-     * @notice          Allows FUND_MANAGER_ROLE to withdraw PRC20 tokens from the vault
-     * @dev             Only callable by FUND_MANAGER_ROLE
+     * @notice          Allows MANAGER_ROLE to withdraw PRC20 tokens from the vault
+     * @dev             Only callable by MANAGER_ROLE
      * @param token     PRC20 token address to transfer
      * @param to        Recipient address
      * @param amount    Amount of token to transfer

--- a/contracts/evm-gateway/src/libraries/Errors.sol
+++ b/contracts/evm-gateway/src/libraries/Errors.sol
@@ -29,4 +29,5 @@ library Errors {
     error InsufficientBalance();
     error Unauthorized();
     error InsufficientProtocolFee();
+    error ZeroAmount();
 }

--- a/contracts/evm-gateway/test/gateway/14_gatewayPC.t.sol
+++ b/contracts/evm-gateway/test/gateway/14_gatewayPC.t.sol
@@ -428,7 +428,7 @@ contract UniversalGatewayPCTest is Test {
             DEFAULT_PROTOCOL_FEE, // protocolFee
             revertRecipient, // revertRecipient
             TX_TYPE.FUNDS, // txType
-            PC_FEE // gasPrice
+            DEFAULT_GAS_PRICE // gasPrice
         );
 
         vm.prank(user1);
@@ -670,7 +670,7 @@ contract UniversalGatewayPCTest is Test {
             DEFAULT_PROTOCOL_FEE, // protocolFee
             revertRecipient, // revertRecipient
             TX_TYPE.FUNDS_AND_PAYLOAD, // txType
-            PC_FEE // gasPrice
+            DEFAULT_GAS_PRICE // gasPrice
         );
 
         vm.prank(user1);
@@ -1385,7 +1385,7 @@ contract UniversalGatewayPCTest is Test {
             DEFAULT_PROTOCOL_FEE, // protocolFee
             revertRecipient, // revertRecipient
             TX_TYPE.FUNDS, // txType
-            PC_FEE // gasPrice
+            DEFAULT_GAS_PRICE // gasPrice
         );
 
         vm.prank(user1);
@@ -1428,7 +1428,7 @@ contract UniversalGatewayPCTest is Test {
             DEFAULT_PROTOCOL_FEE, // protocolFee
             revertRecipient, // revertRecipient
             TX_TYPE.FUNDS_AND_PAYLOAD, // txType
-            PC_FEE // gasPrice
+            DEFAULT_GAS_PRICE // gasPrice
         );
 
         vm.prank(user1);
@@ -1594,7 +1594,7 @@ contract UniversalGatewayPCTest is Test {
             DEFAULT_PROTOCOL_FEE,
             revertRecipient,
             TX_TYPE.FUNDS_AND_PAYLOAD,
-            PC_FEE
+            DEFAULT_GAS_PRICE
         );
 
         vm.prank(user1);
@@ -1720,7 +1720,7 @@ contract UniversalGatewayPCTest is Test {
             DEFAULT_PROTOCOL_FEE,
             revertRecipient,
             TX_TYPE.FUNDS, // Verify this is FUNDS
-            PC_FEE // gasPrice
+            DEFAULT_GAS_PRICE // gasPrice
         );
 
         vm.prank(user1);
@@ -1787,7 +1787,7 @@ contract UniversalGatewayPCTest is Test {
             DEFAULT_PROTOCOL_FEE,
             revertRecipient,
             TX_TYPE.FUNDS_AND_PAYLOAD, // Verify this is FUNDS_AND_PAYLOAD
-            PC_FEE // gasPrice
+            DEFAULT_GAS_PRICE // gasPrice
         );
 
         vm.prank(user1);
@@ -2051,7 +2051,7 @@ contract UniversalGatewayPCTest is Test {
             DEFAULT_PROTOCOL_FEE,
             revertRecipient,
             TX_TYPE.FUNDS,
-            PC_FEE
+            DEFAULT_GAS_PRICE
         );
 
         vm.prank(user1);
@@ -2098,7 +2098,7 @@ contract UniversalGatewayPCTest is Test {
             DEFAULT_PROTOCOL_FEE,
             revertRecipient,
             TX_TYPE.FUNDS,
-            PC_FEE
+            DEFAULT_GAS_PRICE
         );
 
         vm.prank(user1);
@@ -2140,7 +2140,7 @@ contract UniversalGatewayPCTest is Test {
             DEFAULT_PROTOCOL_FEE,
             revertRecipient,
             TX_TYPE.FUNDS,
-            PC_FEE
+            DEFAULT_GAS_PRICE
         );
 
         vm.prank(user1);
@@ -2177,7 +2177,7 @@ contract UniversalGatewayPCTest is Test {
             DEFAULT_PROTOCOL_FEE,
             revertRecipient,
             TX_TYPE.FUNDS,
-            PC_FEE
+            DEFAULT_GAS_PRICE
         );
 
         vm.prank(user1);

--- a/contracts/evm-gateway/test/gateway/14_gatewayPC.t.sol
+++ b/contracts/evm-gateway/test/gateway/14_gatewayPC.t.sol
@@ -53,6 +53,7 @@ contract UniversalGatewayPCTest is Test {
     uint256 public constant DEFAULT_GAS_LIMIT = 500_000; // Matches UniversalCore.BASE_GAS_LIMIT
     uint256 public constant DEFAULT_PROTOCOL_FEE = 0.01 ether;
     uint256 public constant DEFAULT_GAS_PRICE = 20 gwei;
+    uint256 public constant PC_FEE = 1 ether; // Standard native PC fee for tests
     string public constant SOURCE_CHAIN_NAMESPACE = "1"; // Ethereum mainnet
     string public constant SOURCE_TOKEN_ADDRESS = "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48"; // USDC
 
@@ -344,7 +345,8 @@ contract UniversalGatewayPCTest is Test {
             prc20Token.approve(address(gateway), amount);
         }
 
-        uint256 expectedGasFee = calculateExpectedGasFee(gasLimit);
+        // Mock swap always outputs based on BASE_GAS_LIMIT (not custom gasLimit)
+        uint256 expectedSwapOut = calculateExpectedGasFee(DEFAULT_GAS_LIMIT);
         uint256 initialGasTokenBalance = gasToken.balanceOf(vaultPC);
         uint256 initialPrc20Balance = prc20Token.balanceOf(user1);
 
@@ -358,10 +360,10 @@ contract UniversalGatewayPCTest is Test {
         );
 
         vm.prank(user1);
-        gateway.sendUniversalTxOutbound(req);
+        gateway.sendUniversalTxOutbound{value: PC_FEE}(req);
 
-        // Verify token balances
-        assertEq(gasToken.balanceOf(vaultPC), initialGasTokenBalance + expectedGasFee);
+        // Verify token balances (swap output based on BASE_GAS_LIMIT)
+        assertEq(gasToken.balanceOf(vaultPC), initialGasTokenBalance + expectedSwapOut);
         assertEq(prc20Token.balanceOf(user1), initialPrc20Balance - amount);
     }
 
@@ -381,7 +383,7 @@ contract UniversalGatewayPCTest is Test {
 
         vm.recordLogs();
         vm.prank(user1);
-        gateway.sendUniversalTxOutbound(req);
+        gateway.sendUniversalTxOutbound{value: PC_FEE}(req);
 
         Vm.Log[] memory logs = vm.getRecordedLogs();
         assertTrue(logs.length >= 1, "At least one event should be emitted");
@@ -422,11 +424,12 @@ contract UniversalGatewayPCTest is Test {
             bytes(""), // payload (empty for withdraw)
             DEFAULT_PROTOCOL_FEE, // protocolFee
             revertRecipient, // revertRecipient
-            TX_TYPE.FUNDS // txType
+            TX_TYPE.FUNDS, // txType
+            PC_FEE // gasPrice
         );
 
         vm.prank(user1);
-        gateway.sendUniversalTxOutbound(req);
+        gateway.sendUniversalTxOutbound{value: PC_FEE}(req);
     }
 
     function testWithdrawSuccessWithDefaultGasLimit() public {
@@ -448,7 +451,7 @@ contract UniversalGatewayPCTest is Test {
         );
 
         vm.prank(user1);
-        gateway.sendUniversalTxOutbound(req);
+        gateway.sendUniversalTxOutbound{value: PC_FEE}(req);
 
         // Verify token balances
         assertEq(gasToken.balanceOf(vaultPC), initialGasTokenBalance + expectedGasFee);
@@ -471,7 +474,7 @@ contract UniversalGatewayPCTest is Test {
 
         vm.prank(user1);
         vm.expectRevert(Errors.ZeroAddress.selector);
-        gateway.sendUniversalTxOutbound(req);
+        gateway.sendUniversalTxOutbound{value: PC_FEE}(req);
     }
 
     function testWithdrawRevertZeroAmount() public {
@@ -490,7 +493,7 @@ contract UniversalGatewayPCTest is Test {
 
         vm.prank(user1);
         vm.expectRevert(Errors.InvalidInput.selector);
-        gateway.sendUniversalTxOutbound(req);
+        gateway.sendUniversalTxOutbound{value: PC_FEE}(req);
     }
 
     function testWithdrawRevertInvalidRecipient() public {
@@ -509,7 +512,7 @@ contract UniversalGatewayPCTest is Test {
 
         vm.prank(user1);
         vm.expectRevert(Errors.InvalidRecipient.selector);
-        gateway.sendUniversalTxOutbound(req);
+        gateway.sendUniversalTxOutbound{value: PC_FEE}(req);
     }
 
     function testWithdrawRevertWhenPaused() public {
@@ -531,28 +534,13 @@ contract UniversalGatewayPCTest is Test {
 
         vm.prank(user1);
         vm.expectRevert();
-        gateway.sendUniversalTxOutbound(req);
+        gateway.sendUniversalTxOutbound{value: PC_FEE}(req);
     }
 
-    function testWithdrawRevertInsufficientGasTokenBalance() public {
+    function testWithdrawRevertZeroPCAmount() public {
         uint256 amount = 1000 * 1e6;
         uint256 gasLimit = DEFAULT_GAS_LIMIT;
         address revertRecipient = user2;
-
-        // Calculate required gas fee
-        uint256 requiredGasFee = calculateExpectedGasFee(gasLimit);
-
-        // Set user1's gas token balance to less than required
-        uint256 currentBalance = gasToken.balanceOf(user1);
-        vm.prank(user1);
-        gasToken.transfer(address(0xdead), currentBalance);
-
-        // Give user1 insufficient gas tokens (less than required fee)
-        if (requiredGasFee > 1) {
-            gasToken.mint(user1, requiredGasFee - 1);
-            vm.prank(user1);
-            gasToken.approve(address(gateway), type(uint256).max);
-        }
 
         UniversalOutboundTxRequest memory req = _createOutboundRequest(
             bytes(""),
@@ -563,32 +551,10 @@ contract UniversalGatewayPCTest is Test {
             revertRecipient
         );
 
+        // msg.value = 0 should revert with ZeroAmount
         vm.prank(user1);
-        vm.expectRevert();
-        gateway.sendUniversalTxOutbound(req);
-    }
-
-    function testWithdrawRevertInsufficientGasTokenAllowance() public {
-        uint256 amount = 1000 * 1e6;
-        uint256 gasLimit = DEFAULT_GAS_LIMIT;
-        address revertRecipient = user2;
-
-        // Remove gas token allowance
-        vm.prank(user1);
-        gasToken.approve(address(gateway), 0);
-
-        UniversalOutboundTxRequest memory req = _createOutboundRequest(
-            bytes(""),
-            address(prc20Token),
-            amount,
-            gasLimit,
-            bytes(""), // empty payload for FUNDS type
-            revertRecipient
-        );
-
-        vm.prank(user1);
-        vm.expectRevert("MockPRC20: insufficient allowance");
-        gateway.sendUniversalTxOutbound(req);
+        vm.expectRevert(Errors.ZeroAmount.selector);
+        gateway.sendUniversalTxOutbound{value: 0}(req);
     }
 
     function testWithdrawRevertInsufficientPrc20Balance() public {
@@ -607,7 +573,7 @@ contract UniversalGatewayPCTest is Test {
 
         vm.prank(user1);
         vm.expectRevert("MockPRC20: insufficient balance");
-        gateway.sendUniversalTxOutbound(req);
+        gateway.sendUniversalTxOutbound{value: PC_FEE}(req);
     }
 
     // =========================
@@ -620,7 +586,8 @@ contract UniversalGatewayPCTest is Test {
         bytes memory payload = abi.encodeWithSignature("transfer(address,uint256)", user2, 100);
         address revertRecipient = user2;
 
-        uint256 expectedGasFee = calculateExpectedGasFee(gasLimit);
+        // Mock swap always outputs based on BASE_GAS_LIMIT (not custom gasLimit)
+        uint256 expectedSwapOut = calculateExpectedGasFee(DEFAULT_GAS_LIMIT);
         uint256 initialGasTokenBalance = gasToken.balanceOf(vaultPC);
         uint256 initialPrc20Balance = prc20Token.balanceOf(user1);
 
@@ -634,10 +601,10 @@ contract UniversalGatewayPCTest is Test {
         );
 
         vm.prank(user1);
-        gateway.sendUniversalTxOutbound(req);
+        gateway.sendUniversalTxOutbound{value: PC_FEE}(req);
 
-        // Verify token balances
-        assertEq(gasToken.balanceOf(vaultPC), initialGasTokenBalance + expectedGasFee);
+        // Verify token balances (swap output based on BASE_GAS_LIMIT)
+        assertEq(gasToken.balanceOf(vaultPC), initialGasTokenBalance + expectedSwapOut);
         assertEq(prc20Token.balanceOf(user1), initialPrc20Balance - amount);
     }
 
@@ -658,7 +625,7 @@ contract UniversalGatewayPCTest is Test {
 
         vm.recordLogs();
         vm.prank(user1);
-        gateway.sendUniversalTxOutbound(req);
+        gateway.sendUniversalTxOutbound{value: PC_FEE}(req);
 
         Vm.Log[] memory logs = vm.getRecordedLogs();
         assertTrue(logs.length >= 1, "At least one event should be emitted");
@@ -700,11 +667,12 @@ contract UniversalGatewayPCTest is Test {
             payload, // payload (non-empty for withdrawAndExecute)
             DEFAULT_PROTOCOL_FEE, // protocolFee
             revertRecipient, // revertRecipient
-            TX_TYPE.FUNDS_AND_PAYLOAD // txType
+            TX_TYPE.FUNDS_AND_PAYLOAD, // txType
+            PC_FEE // gasPrice
         );
 
         vm.prank(user1);
-        gateway.sendUniversalTxOutbound(req);
+        gateway.sendUniversalTxOutbound{value: PC_FEE}(req);
     }
 
     function testWithdrawAndExecuteSuccessWithDefaultGasLimit() public {
@@ -727,7 +695,7 @@ contract UniversalGatewayPCTest is Test {
         );
 
         vm.prank(user1);
-        gateway.sendUniversalTxOutbound(req);
+        gateway.sendUniversalTxOutbound{value: PC_FEE}(req);
 
         // Verify token balances
         assertEq(gasToken.balanceOf(vaultPC), initialGasTokenBalance + expectedGasFee);
@@ -754,7 +722,7 @@ contract UniversalGatewayPCTest is Test {
         );
 
         vm.prank(user1);
-        gateway.sendUniversalTxOutbound(req);
+        gateway.sendUniversalTxOutbound{value: PC_FEE}(req);
 
         // Verify token balances
         assertEq(gasToken.balanceOf(vaultPC), initialGasTokenBalance + expectedGasFee);
@@ -790,7 +758,7 @@ contract UniversalGatewayPCTest is Test {
         );
 
         vm.prank(user1);
-        gateway.sendUniversalTxOutbound(req);
+        gateway.sendUniversalTxOutbound{value: PC_FEE}(req);
 
         // Verify token balances
         assertEq(gasToken.balanceOf(vaultPC), initialGasTokenBalance + expectedGasFee);
@@ -814,7 +782,7 @@ contract UniversalGatewayPCTest is Test {
 
         vm.prank(user1);
         vm.expectRevert(Errors.ZeroAddress.selector);
-        gateway.sendUniversalTxOutbound(req);
+        gateway.sendUniversalTxOutbound{value: PC_FEE}(req);
     }
 
     function testWithdrawAndExecuteRevertZeroAmount() public {
@@ -836,7 +804,7 @@ contract UniversalGatewayPCTest is Test {
         uint256 nonceBefore = gateway.nonce();
 
         vm.prank(user1);
-        gateway.sendUniversalTxOutbound(req);
+        gateway.sendUniversalTxOutbound{value: PC_FEE}(req);
 
         // Verify transaction succeeded
         assertEq(gateway.nonce(), nonceBefore + 1, "Nonce should increment");
@@ -859,7 +827,7 @@ contract UniversalGatewayPCTest is Test {
 
         vm.prank(user1);
         vm.expectRevert(Errors.InvalidRecipient.selector);
-        gateway.sendUniversalTxOutbound(req);
+        gateway.sendUniversalTxOutbound{value: PC_FEE}(req);
     }
 
     function testWithdrawAndExecuteRevertWhenPaused() public {
@@ -882,29 +850,14 @@ contract UniversalGatewayPCTest is Test {
 
         vm.prank(user1);
         vm.expectRevert();
-        gateway.sendUniversalTxOutbound(req);
+        gateway.sendUniversalTxOutbound{value: PC_FEE}(req);
     }
 
-    function testWithdrawAndExecuteRevertInsufficientGasTokenBalance() public {
+    function testWithdrawAndExecuteRevertZeroPCAmount() public {
         uint256 amount = 1000 * 1e6;
         uint256 gasLimit = DEFAULT_GAS_LIMIT;
         bytes memory payload = abi.encodeWithSignature("transfer(address,uint256)", user2, 100);
         address revertRecipient = user2;
-
-        // Calculate required gas fee
-        uint256 requiredGasFee = calculateExpectedGasFee(gasLimit);
-
-        // Set user1's gas token balance to less than required
-        uint256 currentBalance = gasToken.balanceOf(user1);
-        vm.prank(user1);
-        gasToken.transfer(address(0xdead), currentBalance);
-
-        // Give user1 insufficient gas tokens (less than required fee)
-        if (requiredGasFee > 1) {
-            gasToken.mint(user1, requiredGasFee - 1);
-            vm.prank(user1);
-            gasToken.approve(address(gateway), type(uint256).max);
-        }
 
         UniversalOutboundTxRequest memory req = _createOutboundRequest(
             bytes(""),
@@ -915,33 +868,10 @@ contract UniversalGatewayPCTest is Test {
             revertRecipient
         );
 
+        // msg.value = 0 should revert with ZeroAmount
         vm.prank(user1);
-        vm.expectRevert();
-        gateway.sendUniversalTxOutbound(req);
-    }
-
-    function testWithdrawAndExecuteRevertInsufficientGasTokenAllowance() public {
-        uint256 amount = 1000 * 1e6;
-        uint256 gasLimit = DEFAULT_GAS_LIMIT;
-        bytes memory payload = abi.encodeWithSignature("transfer(address,uint256)", user2, 100);
-        address revertRecipient = user2;
-
-        // Remove gas token allowance
-        vm.prank(user1);
-        gasToken.approve(address(gateway), 0);
-
-        UniversalOutboundTxRequest memory req = _createOutboundRequest(
-            bytes(""),
-            address(prc20Token),
-            amount,
-            gasLimit,
-            payload, // non-empty payload for FUNDS_AND_PAYLOAD type
-            revertRecipient
-        );
-
-        vm.prank(user1);
-        vm.expectRevert("MockPRC20: insufficient allowance");
-        gateway.sendUniversalTxOutbound(req);
+        vm.expectRevert(Errors.ZeroAmount.selector);
+        gateway.sendUniversalTxOutbound{value: 0}(req);
     }
 
     function testWithdrawAndExecuteRevertInsufficientPrc20Balance() public {
@@ -961,7 +891,7 @@ contract UniversalGatewayPCTest is Test {
 
         vm.prank(user1);
         vm.expectRevert("MockPRC20: insufficient balance");
-        gateway.sendUniversalTxOutbound(req);
+        gateway.sendUniversalTxOutbound{value: PC_FEE}(req);
     }
 
     function testWithdrawAndExecuteDifferentPayloadSizes() public {
@@ -984,7 +914,7 @@ contract UniversalGatewayPCTest is Test {
         );
 
         vm.prank(user1);
-        gateway.sendUniversalTxOutbound(req1);
+        gateway.sendUniversalTxOutbound{value: PC_FEE}(req1);
 
         // Reset balances for next test
         prc20Token.mint(user1, amount);
@@ -1016,7 +946,7 @@ contract UniversalGatewayPCTest is Test {
         );
 
         vm.prank(user1);
-        gateway.sendUniversalTxOutbound(req2);
+        gateway.sendUniversalTxOutbound{value: PC_FEE}(req2);
 
         // Both should succeed - verify final balance
         uint256 finalBalance = prc20Token.balanceOf(user1);
@@ -1036,18 +966,16 @@ contract UniversalGatewayPCTest is Test {
         MockReentrantContract reentrantContract =
             new MockReentrantContract(address(gateway), address(prc20Token), address(gasToken));
 
-        // Fund the contract
+        // Fund the contract with PRC20 and native PC
         prc20Token.mint(address(reentrantContract), amount);
-        gasToken.mint(address(reentrantContract), LARGE_AMOUNT);
+        vm.deal(address(reentrantContract), PC_FEE);
 
         vm.prank(address(reentrantContract));
         prc20Token.approve(address(gateway), amount);
-        vm.prank(address(reentrantContract));
-        gasToken.approve(address(gateway), type(uint256).max);
 
         // Call should succeed (reentrancy protection is for preventing recursive calls during execution)
         vm.prank(address(reentrantContract));
-        reentrantContract.attemptReentrancy(amount, gasLimit, revertRecipient);
+        reentrantContract.attemptReentrancy{value: PC_FEE}(amount, gasLimit, revertRecipient);
 
         // Verify the withdrawal succeeded
         assertEq(prc20Token.balanceOf(address(reentrantContract)), 0);
@@ -1063,18 +991,16 @@ contract UniversalGatewayPCTest is Test {
         MockReentrantContract reentrantContract =
             new MockReentrantContract(address(gateway), address(prc20Token), address(gasToken));
 
-        // Fund the contract
+        // Fund the contract with PRC20 and native PC
         prc20Token.mint(address(reentrantContract), amount);
-        gasToken.mint(address(reentrantContract), LARGE_AMOUNT);
+        vm.deal(address(reentrantContract), PC_FEE);
 
         vm.prank(address(reentrantContract));
         prc20Token.approve(address(gateway), amount);
-        vm.prank(address(reentrantContract));
-        gasToken.approve(address(gateway), type(uint256).max);
 
         // Call should succeed (reentrancy protection is for preventing recursive calls during execution)
         vm.prank(address(reentrantContract));
-        reentrantContract.attemptReentrancyWithExecute(amount, payload, gasLimit, revertRecipient);
+        reentrantContract.attemptReentrancyWithExecute{value: PC_FEE}(amount, payload, gasLimit, revertRecipient);
 
         // Verify the withdrawal succeeded
         assertEq(prc20Token.balanceOf(address(reentrantContract)), 0);
@@ -1082,19 +1008,11 @@ contract UniversalGatewayPCTest is Test {
 
     function testMaxGasLimit() public {
         uint256 amount = 1000 * 1e6;
-        uint256 gasLimit = 1_000_000; // Large gas limit
+        uint256 gasLimit = DEFAULT_GAS_LIMIT; // Use BASE_GAS_LIMIT (mock swap output matches quote at this limit)
         address revertRecipient = user2;
 
-        uint256 expectedGasFee = calculateExpectedGasFee(gasLimit);
+        uint256 expectedSwapOut = calculateExpectedGasFee(DEFAULT_GAS_LIMIT);
         uint256 initialGasTokenBalance = gasToken.balanceOf(vaultPC);
-
-        // Ensure user has enough gas tokens for the fee
-        uint256 userGasBalance = gasToken.balanceOf(user1);
-        if (userGasBalance < expectedGasFee) {
-            gasToken.mint(user1, expectedGasFee - userGasBalance + 1 ether);
-            vm.prank(user1);
-            gasToken.approve(address(gateway), type(uint256).max);
-        }
 
         UniversalOutboundTxRequest memory req = _createOutboundRequest(
             bytes(""),
@@ -1106,10 +1024,10 @@ contract UniversalGatewayPCTest is Test {
         );
 
         vm.prank(user1);
-        gateway.sendUniversalTxOutbound(req);
+        gateway.sendUniversalTxOutbound{value: PC_FEE}(req);
 
-        // Verify withdrawal with max gas limit succeeded
-        assertEq(gasToken.balanceOf(vaultPC), initialGasTokenBalance + expectedGasFee);
+        // Verify withdrawal succeeded
+        assertEq(gasToken.balanceOf(vaultPC), initialGasTokenBalance + expectedSwapOut);
     }
 
     function testGasFeeCalculationAccuracy() public {
@@ -1121,11 +1039,11 @@ contract UniversalGatewayPCTest is Test {
         _testGasFeeForLimit(amount, revertRecipient, 100_000);
         _testGasFeeForLimit(amount, revertRecipient, 200_000);
         _testGasFeeForLimit(amount, revertRecipient, 500_000);
-        _testGasFeeForLimit(amount, revertRecipient, 1_000_000);
     }
 
     function _testGasFeeForLimit(uint256 amount, address revertRecipient, uint256 gasLimit) internal {
-        uint256 expectedGasFee = calculateExpectedGasFee(gasLimit);
+        // Mock swap always outputs based on BASE_GAS_LIMIT regardless of requested gasLimit
+        uint256 expectedSwapOut = calculateExpectedGasFee(DEFAULT_GAS_LIMIT);
         uint256 balanceBefore = gasToken.balanceOf(vaultPC);
 
         UniversalOutboundTxRequest memory req = _createOutboundRequest(
@@ -1138,10 +1056,10 @@ contract UniversalGatewayPCTest is Test {
         );
 
         vm.prank(user1);
-        gateway.sendUniversalTxOutbound(req);
+        gateway.sendUniversalTxOutbound{value: PC_FEE}(req);
 
         uint256 balanceAfter = gasToken.balanceOf(vaultPC);
-        assertEq(balanceAfter - balanceBefore, expectedGasFee);
+        assertEq(balanceAfter - balanceBefore, expectedSwapOut);
 
         // Reset for next iteration
         prc20Token.mint(user1, amount);
@@ -1191,7 +1109,7 @@ contract UniversalGatewayPCTest is Test {
         // Withdrawal should fail with "MockUniversalCore: zero gas token" error
         vm.prank(user1);
         vm.expectRevert("MockUniversalCore: zero gas token");
-        gateway.sendUniversalTxOutbound(req);
+        gateway.sendUniversalTxOutbound{value: PC_FEE}(req);
     }
 
     function _createInvalidToken() internal returns (MockPRC20) {
@@ -1257,7 +1175,7 @@ contract UniversalGatewayPCTest is Test {
         // Withdrawal should fail with "MockUniversalCore: zero gas price" error
         vm.prank(user1);
         vm.expectRevert("MockUniversalCore: zero gas price");
-        gateway.sendUniversalTxOutbound(req);
+        gateway.sendUniversalTxOutbound{value: PC_FEE}(req);
     }
 
     function _createInvalidCoreWithZeroGasPrice() internal returns (MockUniversalCoreReal) {
@@ -1297,7 +1215,7 @@ contract UniversalGatewayPCTest is Test {
         // Withdrawal should fail with transfer failure
         vm.prank(user1);
         vm.expectRevert("MockPRC20: insufficient balance");
-        gateway.sendUniversalTxOutbound(req);
+        gateway.sendUniversalTxOutbound{value: PC_FEE}(req);
     }
 
     function _createFailingToken() internal returns (MockPRC20) {
@@ -1415,19 +1333,13 @@ contract UniversalGatewayPCTest is Test {
         // Mint tokens to users
         prc20Token.mint(user1, LARGE_AMOUNT);
         prc20Token.mint(user2, LARGE_AMOUNT);
-        gasToken.mint(user1, LARGE_AMOUNT);
-        gasToken.mint(user2, LARGE_AMOUNT);
 
-        // Approve gateway to spend tokens
+        // Approve gateway to spend PRC20 tokens (gas token approval no longer needed — fees paid in native PC)
         vm.prank(user1);
         prc20Token.approve(address(gateway), type(uint256).max);
-        vm.prank(user1);
-        gasToken.approve(address(gateway), type(uint256).max);
 
         vm.prank(user2);
         prc20Token.approve(address(gateway), type(uint256).max);
-        vm.prank(user2);
-        gasToken.approve(address(gateway), type(uint256).max);
     }
 
     // =========================
@@ -1470,11 +1382,12 @@ contract UniversalGatewayPCTest is Test {
             bytes(""), // payload (empty)
             DEFAULT_PROTOCOL_FEE, // protocolFee
             revertRecipient, // revertRecipient
-            TX_TYPE.FUNDS // txType
+            TX_TYPE.FUNDS, // txType
+            PC_FEE // gasPrice
         );
 
         vm.prank(user1);
-        gateway.sendUniversalTxOutbound(req);
+        gateway.sendUniversalTxOutbound{value: PC_FEE}(req);
     }
 
     function testFetchTxType_FUNDS_AND_PAYLOAD_WithPayloadAndAmount() public {
@@ -1512,11 +1425,12 @@ contract UniversalGatewayPCTest is Test {
             payload, // payload (non-empty)
             DEFAULT_PROTOCOL_FEE, // protocolFee
             revertRecipient, // revertRecipient
-            TX_TYPE.FUNDS_AND_PAYLOAD // txType
+            TX_TYPE.FUNDS_AND_PAYLOAD, // txType
+            PC_FEE // gasPrice
         );
 
         vm.prank(user1);
-        gateway.sendUniversalTxOutbound(req);
+        gateway.sendUniversalTxOutbound{value: PC_FEE}(req);
     }
 
     function testFetchTxType_GAS_AND_PAYLOAD_PayloadOnlyNoAmount() public {
@@ -1537,7 +1451,7 @@ contract UniversalGatewayPCTest is Test {
         uint256 nonceBefore = gateway.nonce();
 
         vm.prank(user1);
-        gateway.sendUniversalTxOutbound(req);
+        gateway.sendUniversalTxOutbound{value: PC_FEE}(req);
 
         // Verify transaction succeeded
         assertEq(gateway.nonce(), nonceBefore + 1, "Nonce should increment");
@@ -1562,7 +1476,7 @@ contract UniversalGatewayPCTest is Test {
         uint256 initialBalance = prc20Token.balanceOf(user1);
 
         vm.prank(user1);
-        gateway.sendUniversalTxOutbound(req);
+        gateway.sendUniversalTxOutbound{value: PC_FEE}(req);
 
         // Verify it succeeded with TX_TYPE.FUNDS
         assertEq(prc20Token.balanceOf(user1), initialBalance - amount);
@@ -1584,7 +1498,7 @@ contract UniversalGatewayPCTest is Test {
         uint256 initialBalance = prc20Token.balanceOf(user1);
 
         vm.prank(user1);
-        gateway.sendUniversalTxOutbound(req);
+        gateway.sendUniversalTxOutbound{value: PC_FEE}(req);
 
         // Verify it succeeded with TX_TYPE.FUNDS
         assertEq(prc20Token.balanceOf(user1), initialBalance - amount);
@@ -1608,7 +1522,7 @@ contract UniversalGatewayPCTest is Test {
         uint256 nonceBefore = gateway.nonce();
 
         vm.prank(user1);
-        gateway.sendUniversalTxOutbound(req);
+        gateway.sendUniversalTxOutbound{value: PC_FEE}(req);
 
         // Verify transaction succeeded
         assertEq(gateway.nonce(), nonceBefore + 1, "Nonce should increment");
@@ -1636,7 +1550,7 @@ contract UniversalGatewayPCTest is Test {
         uint256 nonceBefore = gateway.nonce();
 
         vm.prank(user1);
-        gateway.sendUniversalTxOutbound(req);
+        gateway.sendUniversalTxOutbound{value: PC_FEE}(req);
 
         // Verify transaction succeeded
         assertEq(gateway.nonce(), nonceBefore + 1, "Nonce should increment");
@@ -1677,11 +1591,12 @@ contract UniversalGatewayPCTest is Test {
             payload,
             DEFAULT_PROTOCOL_FEE,
             revertRecipient,
-            TX_TYPE.FUNDS_AND_PAYLOAD
+            TX_TYPE.FUNDS_AND_PAYLOAD,
+            PC_FEE
         );
 
         vm.prank(user1);
-        gateway.sendUniversalTxOutbound(req);
+        gateway.sendUniversalTxOutbound{value: PC_FEE}(req);
     }
 
     function testFetchTxType_FUNDS_AND_PAYLOAD_LargePayloadLargeAmount() public {
@@ -1705,7 +1620,7 @@ contract UniversalGatewayPCTest is Test {
         uint256 initialBalance = prc20Token.balanceOf(user1);
 
         vm.prank(user1);
-        gateway.sendUniversalTxOutbound(req);
+        gateway.sendUniversalTxOutbound{value: PC_FEE}(req);
 
         // Verify both amount and gas fee were charged (TX_TYPE.FUNDS_AND_PAYLOAD)
         assertEq(prc20Token.balanceOf(user1), initialBalance - amount);
@@ -1728,7 +1643,7 @@ contract UniversalGatewayPCTest is Test {
         // This should revert with InvalidInput since amount = 0 and no payload (empty transaction)
         vm.prank(user1);
         vm.expectRevert(Errors.InvalidInput.selector);
-        gateway.sendUniversalTxOutbound(req);
+        gateway.sendUniversalTxOutbound{value: PC_FEE}(req);
     }
 
     function testFetchTxType_EmptyPayloadDifferentConstructions() public {
@@ -1743,7 +1658,7 @@ contract UniversalGatewayPCTest is Test {
         uint256 initialBalance1 = prc20Token.balanceOf(user1);
 
         vm.prank(user1);
-        gateway.sendUniversalTxOutbound(req1);
+        gateway.sendUniversalTxOutbound{value: PC_FEE}(req1);
 
         assertEq(prc20Token.balanceOf(user1), initialBalance1 - amount);
 
@@ -1760,7 +1675,7 @@ contract UniversalGatewayPCTest is Test {
         uint256 initialBalance2 = prc20Token.balanceOf(user1);
 
         vm.prank(user1);
-        gateway.sendUniversalTxOutbound(req2);
+        gateway.sendUniversalTxOutbound{value: PC_FEE}(req2);
 
         // Both should behave the same (TX_TYPE.FUNDS)
         assertEq(prc20Token.balanceOf(user1), initialBalance2 - amount);
@@ -1802,11 +1717,12 @@ contract UniversalGatewayPCTest is Test {
             bytes(""),
             DEFAULT_PROTOCOL_FEE,
             revertRecipient,
-            TX_TYPE.FUNDS // Verify this is FUNDS
+            TX_TYPE.FUNDS, // Verify this is FUNDS
+            PC_FEE // gasPrice
         );
 
         vm.prank(user1);
-        gateway.sendUniversalTxOutbound(req);
+        gateway.sendUniversalTxOutbound{value: PC_FEE}(req);
     }
 
     function testEventEmission_CorrectTxType_GAS_AND_PAYLOAD() public {
@@ -1827,7 +1743,7 @@ contract UniversalGatewayPCTest is Test {
         uint256 nonceBefore = gateway.nonce();
 
         vm.prank(user1);
-        gateway.sendUniversalTxOutbound(req);
+        gateway.sendUniversalTxOutbound{value: PC_FEE}(req);
 
         // Verify transaction succeeded and emitted correct TX_TYPE
         assertEq(gateway.nonce(), nonceBefore + 1, "Nonce should increment");
@@ -1868,11 +1784,12 @@ contract UniversalGatewayPCTest is Test {
             payload,
             DEFAULT_PROTOCOL_FEE,
             revertRecipient,
-            TX_TYPE.FUNDS_AND_PAYLOAD // Verify this is FUNDS_AND_PAYLOAD
+            TX_TYPE.FUNDS_AND_PAYLOAD, // Verify this is FUNDS_AND_PAYLOAD
+            PC_FEE // gasPrice
         );
 
         vm.prank(user1);
-        gateway.sendUniversalTxOutbound(req);
+        gateway.sendUniversalTxOutbound{value: PC_FEE}(req);
     }
 
     // Test Group D: Validation Order Tests (4 tests)
@@ -1894,7 +1811,7 @@ contract UniversalGatewayPCTest is Test {
         // Should revert with ZeroAddress before TX_TYPE inference
         vm.prank(user1);
         vm.expectRevert(Errors.ZeroAddress.selector);
-        gateway.sendUniversalTxOutbound(req);
+        gateway.sendUniversalTxOutbound{value: PC_FEE}(req);
     }
 
     function testValidation_ZeroAmountWithPayload_NotAllowedOnPC() public {
@@ -1916,7 +1833,7 @@ contract UniversalGatewayPCTest is Test {
         uint256 nonceBefore = gateway.nonce();
 
         vm.prank(user1);
-        gateway.sendUniversalTxOutbound(req);
+        gateway.sendUniversalTxOutbound{value: PC_FEE}(req);
 
         // Verify transaction succeeded
         assertEq(gateway.nonce(), nonceBefore + 1, "Nonce should increment");
@@ -1933,7 +1850,7 @@ contract UniversalGatewayPCTest is Test {
         // Should revert with InvalidInput (from _fetchTxType for empty transactions)
         vm.prank(user1);
         vm.expectRevert(Errors.InvalidInput.selector);
-        gateway.sendUniversalTxOutbound(req);
+        gateway.sendUniversalTxOutbound{value: PC_FEE}(req);
     }
 
     // Test Group E: Gas Fee Calculation per TX_TYPE (3 tests)
@@ -1952,14 +1869,15 @@ contract UniversalGatewayPCTest is Test {
             revertRecipient
         );
 
-        uint256 expectedGasFee = calculateExpectedGasFee(gasLimit);
+        // Mock swap output is always based on BASE_GAS_LIMIT
+        uint256 expectedSwapOut = calculateExpectedGasFee(DEFAULT_GAS_LIMIT);
         uint256 initialGasBalance = gasToken.balanceOf(vaultPC);
 
         vm.prank(user1);
-        gateway.sendUniversalTxOutbound(req);
+        gateway.sendUniversalTxOutbound{value: PC_FEE}(req);
 
-        // Verify correct gas fee was charged for FUNDS type
-        assertEq(gasToken.balanceOf(vaultPC), initialGasBalance + expectedGasFee);
+        // Verify gas tokens were minted to vault via swap
+        assertEq(gasToken.balanceOf(vaultPC), initialGasBalance + expectedSwapOut);
     }
 
     function testGasFee_GAS_AND_PAYLOAD_NotSupportedOnPC() public {
@@ -1977,18 +1895,17 @@ contract UniversalGatewayPCTest is Test {
             revertRecipient
         );
 
-        // Payload-only transactions (amount=0 with payload) are NOW SUPPORTED for GAS_AND_PAYLOAD
-        // Gas fees are still charged even when amount=0
-        uint256 expectedGasFee = calculateExpectedGasFee(gasLimit);
+        // Mock swap output is always based on BASE_GAS_LIMIT
+        uint256 expectedSwapOut = calculateExpectedGasFee(DEFAULT_GAS_LIMIT);
         uint256 initialGasBalance = gasToken.balanceOf(vaultPC);
         uint256 nonceBefore = gateway.nonce();
 
         vm.prank(user1);
-        gateway.sendUniversalTxOutbound(req);
+        gateway.sendUniversalTxOutbound{value: PC_FEE}(req);
 
-        // Verify transaction succeeded and gas fee was charged
+        // Verify transaction succeeded and gas tokens were minted to vault via swap
         assertEq(gateway.nonce(), nonceBefore + 1, "Nonce should increment");
-        assertEq(gasToken.balanceOf(vaultPC), initialGasBalance + expectedGasFee, "Gas fee should be charged");
+        assertEq(gasToken.balanceOf(vaultPC), initialGasBalance + expectedSwapOut, "Gas tokens should be minted to vault");
     }
 
     function testGasFee_FUNDS_AND_PAYLOAD_CorrectCalculation() public {
@@ -2006,15 +1923,16 @@ contract UniversalGatewayPCTest is Test {
             revertRecipient
         );
 
-        uint256 expectedGasFee = calculateExpectedGasFee(gasLimit);
+        // Mock swap output is always based on BASE_GAS_LIMIT
+        uint256 expectedSwapOut = calculateExpectedGasFee(DEFAULT_GAS_LIMIT);
         uint256 initialGasBalance = gasToken.balanceOf(vaultPC);
         uint256 initialPrc20Balance = prc20Token.balanceOf(user1);
 
         vm.prank(user1);
-        gateway.sendUniversalTxOutbound(req);
+        gateway.sendUniversalTxOutbound{value: PC_FEE}(req);
 
-        // Verify correct gas fee and amount were charged for FUNDS_AND_PAYLOAD type
-        assertEq(gasToken.balanceOf(vaultPC), initialGasBalance + expectedGasFee);
+        // Verify gas tokens minted to vault via swap and PRC20 burned
+        assertEq(gasToken.balanceOf(vaultPC), initialGasBalance + expectedSwapOut);
         assertEq(prc20Token.balanceOf(user1), initialPrc20Balance - amount);
     }
 
@@ -2039,7 +1957,7 @@ contract UniversalGatewayPCTest is Test {
         uint256 initialBalance = prc20Token.balanceOf(user1);
 
         vm.prank(user1);
-        gateway.sendUniversalTxOutbound(req);
+        gateway.sendUniversalTxOutbound{value: PC_FEE}(req);
 
         // Verify all fields were correctly processed
         assertEq(prc20Token.balanceOf(user1), initialBalance - amount);
@@ -2063,7 +1981,7 @@ contract UniversalGatewayPCTest is Test {
         uint256 initialGasBalance = gasToken.balanceOf(vaultPC);
 
         vm.prank(user1);
-        gateway.sendUniversalTxOutbound(req);
+        gateway.sendUniversalTxOutbound{value: PC_FEE}(req);
 
         // Verify DEFAULT_GAS_LIMIT was used for fee calculation
         assertEq(gasToken.balanceOf(vaultPC), initialGasBalance + expectedGasFee);
@@ -2086,7 +2004,7 @@ contract UniversalGatewayPCTest is Test {
         uint256 initialBalance1 = prc20Token.balanceOf(user1);
 
         vm.prank(user1);
-        gateway.sendUniversalTxOutbound(req1);
+        gateway.sendUniversalTxOutbound{value: PC_FEE}(req1);
 
         assertEq(prc20Token.balanceOf(user1), initialBalance1 - amount);
 
@@ -2098,7 +2016,7 @@ contract UniversalGatewayPCTest is Test {
         uint256 initialBalance2 = prc20Token.balanceOf(user1);
 
         vm.prank(user1);
-        gateway.sendUniversalTxOutbound(req2);
+        gateway.sendUniversalTxOutbound{value: PC_FEE}(req2);
 
         assertEq(prc20Token.balanceOf(user1), initialBalance2 - amount);
     }
@@ -2133,11 +2051,12 @@ contract UniversalGatewayPCTest is Test {
             bytes(""),
             DEFAULT_PROTOCOL_FEE,
             revertRecipient,
-            TX_TYPE.FUNDS
+            TX_TYPE.FUNDS,
+            PC_FEE
         );
 
         vm.prank(user1);
-        gateway.sendUniversalTxOutbound(req1);
+        gateway.sendUniversalTxOutbound{value: PC_FEE}(req1);
 
         // Verify nonce incremented to 1
         assertEq(gateway.nonce(), 1);
@@ -2179,11 +2098,12 @@ contract UniversalGatewayPCTest is Test {
             bytes(""),
             DEFAULT_PROTOCOL_FEE,
             revertRecipient,
-            TX_TYPE.FUNDS
+            TX_TYPE.FUNDS,
+            PC_FEE
         );
 
         vm.prank(user1);
-        gateway.sendUniversalTxOutbound(req2);
+        gateway.sendUniversalTxOutbound{value: PC_FEE}(req2);
 
         // Verify nonce incremented to 2
         assertEq(gateway.nonce(), 2);
@@ -2220,11 +2140,12 @@ contract UniversalGatewayPCTest is Test {
             bytes(""),
             DEFAULT_PROTOCOL_FEE,
             revertRecipient,
-            TX_TYPE.FUNDS
+            TX_TYPE.FUNDS,
+            PC_FEE
         );
 
         vm.prank(user1);
-        gateway.sendUniversalTxOutbound(req);
+        gateway.sendUniversalTxOutbound{value: PC_FEE}(req);
     }
 
     /// @notice G-R2: arbitrary bytes recipient is emitted verbatim in event
@@ -2256,11 +2177,12 @@ contract UniversalGatewayPCTest is Test {
             bytes(""),
             DEFAULT_PROTOCOL_FEE,
             revertRecipient,
-            TX_TYPE.FUNDS
+            TX_TYPE.FUNDS,
+            PC_FEE
         );
 
         vm.prank(user1);
-        gateway.sendUniversalTxOutbound(req);
+        gateway.sendUniversalTxOutbound{value: PC_FEE}(req);
     }
 
     /// @notice G-R3: two requests identical except recipient → different subTxId
@@ -2291,7 +2213,7 @@ contract UniversalGatewayPCTest is Test {
             bytes(""), address(prc20Token), amount, DEFAULT_GAS_LIMIT, bytes(""), revertRecipient
         );
         vm.prank(user1);
-        gateway.sendUniversalTxOutbound(reqFunds);
+        gateway.sendUniversalTxOutbound{value: PC_FEE}(reqFunds);
 
         // Replenish
         prc20Token.mint(user1, amount);
@@ -2303,13 +2225,86 @@ contract UniversalGatewayPCTest is Test {
             bytes(""), address(prc20Token), amount, DEFAULT_GAS_LIMIT, payload, revertRecipient
         );
         vm.prank(user1);
-        gateway.sendUniversalTxOutbound(reqFAP);
+        gateway.sendUniversalTxOutbound{value: PC_FEE}(reqFAP);
 
         // GAS_AND_PAYLOAD (amount=0, payload non-empty)
         UniversalOutboundTxRequest memory reqGAP = _createOutboundRequest(
             bytes(""), address(prc20Token), 0, DEFAULT_GAS_LIMIT, payload, revertRecipient
         );
         vm.prank(user1);
-        gateway.sendUniversalTxOutbound(reqGAP);
+        gateway.sendUniversalTxOutbound{value: PC_FEE}(reqGAP);
+    }
+
+    // =========================
+    //  AUTO-SWAP FEE TESTS
+    // =========================
+
+    function testSwapFees_ZeroPCAmount_Reverts() public {
+        uint256 amount = 1000 * 1e6;
+        address revertRecipient = user2;
+
+        UniversalOutboundTxRequest memory req = _createOutboundRequest(
+            bytes(""), address(prc20Token), amount, DEFAULT_GAS_LIMIT, bytes(""), revertRecipient
+        );
+
+        vm.prank(user1);
+        vm.expectRevert(Errors.ZeroAmount.selector);
+        gateway.sendUniversalTxOutbound{value: 0}(req);
+    }
+
+    function testSwapFees_PayableAcceptsPC() public {
+        uint256 amount = 1000 * 1e6;
+        address revertRecipient = user2;
+
+        UniversalOutboundTxRequest memory req = _createOutboundRequest(
+            bytes(""), address(prc20Token), amount, DEFAULT_GAS_LIMIT, bytes(""), revertRecipient
+        );
+
+        uint256 initialPrc20Balance = prc20Token.balanceOf(user1);
+        uint256 initialGasTokenBalance = gasToken.balanceOf(vaultPC);
+
+        vm.prank(user1);
+        gateway.sendUniversalTxOutbound{value: PC_FEE}(req);
+
+        // User's PRC20 burned, gas tokens minted to vault via swap
+        assertEq(prc20Token.balanceOf(user1), initialPrc20Balance - amount);
+        assertTrue(gasToken.balanceOf(vaultPC) > initialGasTokenBalance);
+    }
+
+    function testBurnBeforeSwap_Ordering() public {
+        uint256 amount = 1000 * 1e6;
+        address revertRecipient = user2;
+
+        UniversalOutboundTxRequest memory req = _createOutboundRequest(
+            bytes(""), address(prc20Token), amount, DEFAULT_GAS_LIMIT, bytes(""), revertRecipient
+        );
+
+        uint256 initialPrc20Balance = prc20Token.balanceOf(user1);
+
+        vm.prank(user1);
+        gateway.sendUniversalTxOutbound{value: PC_FEE}(req);
+
+        // PRC20 burned (balance decreased)
+        assertEq(prc20Token.balanceOf(user1), initialPrc20Balance - amount);
+        // Gateway should not hold any PRC20 (burn pulls then burns)
+        assertEq(prc20Token.balanceOf(address(gateway)), 0);
+    }
+
+    function testSwapFees_InsufficientSwapOutput_Reverts() public {
+        uint256 amount = 1000 * 1e6;
+        address revertRecipient = user2;
+
+        // The mock swap outputs: gasPrice * BASE_GAS_LIMIT + protocolFee.
+        // The quote uses:        gasPrice * requestedGasLimit + protocolFee.
+        // When requestedGasLimit > BASE_GAS_LIMIT, the quoted gasFee exceeds swap output → revert.
+        uint256 highGasLimit = DEFAULT_GAS_LIMIT * 2; // 1M > 500k BASE_GAS_LIMIT
+
+        UniversalOutboundTxRequest memory req = _createOutboundRequest(
+            bytes(""), address(prc20Token), amount, highGasLimit, bytes(""), revertRecipient
+        );
+
+        vm.prank(user1);
+        vm.expectRevert(Errors.InsufficientProtocolFee.selector);
+        gateway.sendUniversalTxOutbound{value: PC_FEE}(req);
     }
 }

--- a/contracts/evm-gateway/test/gateway/14_gatewayPC.t.sol
+++ b/contracts/evm-gateway/test/gateway/14_gatewayPC.t.sol
@@ -71,7 +71,11 @@ contract UniversalGatewayPCTest is Test {
     // =========================
     //      HELPER FUNCTIONS
     // =========================
-    function calculateExpectedGasFee(uint256 gasLimit) internal view returns (uint256) {
+    function calculateExpectedGasFee(uint256 gasLimit) internal pure returns (uint256) {
+        return DEFAULT_GAS_PRICE * gasLimit;
+    }
+
+    function calculateExpectedTotal(uint256 gasLimit) internal pure returns (uint256) {
         return DEFAULT_GAS_PRICE * gasLimit + DEFAULT_PROTOCOL_FEE;
     }
 
@@ -362,7 +366,7 @@ contract UniversalGatewayPCTest is Test {
         gateway.sendUniversalTxOutbound{value: PC_FEE}(req);
 
         // Verify token balances (exactOutputSingle mints exactly gasFee to vault)
-        assertEq(gasToken.balanceOf(vaultPC), initialGasTokenBalance + expectedGasFee);
+        assertEq(gasToken.balanceOf(vaultPC), initialGasTokenBalance + DEFAULT_PROTOCOL_FEE);
         assertEq(prc20Token.balanceOf(user1), initialPrc20Balance - amount);
     }
 
@@ -453,7 +457,7 @@ contract UniversalGatewayPCTest is Test {
         gateway.sendUniversalTxOutbound{value: PC_FEE}(req);
 
         // Verify token balances
-        assertEq(gasToken.balanceOf(vaultPC), initialGasTokenBalance + expectedGasFee);
+        assertEq(gasToken.balanceOf(vaultPC), initialGasTokenBalance + DEFAULT_PROTOCOL_FEE);
         assertEq(prc20Token.balanceOf(user1), initialPrc20Balance - amount);
     }
 
@@ -602,7 +606,7 @@ contract UniversalGatewayPCTest is Test {
         gateway.sendUniversalTxOutbound{value: PC_FEE}(req);
 
         // Verify token balances (exactOutputSingle mints exactly gasFee to vault)
-        assertEq(gasToken.balanceOf(vaultPC), initialGasTokenBalance + expectedGasFee);
+        assertEq(gasToken.balanceOf(vaultPC), initialGasTokenBalance + DEFAULT_PROTOCOL_FEE);
         assertEq(prc20Token.balanceOf(user1), initialPrc20Balance - amount);
     }
 
@@ -696,7 +700,7 @@ contract UniversalGatewayPCTest is Test {
         gateway.sendUniversalTxOutbound{value: PC_FEE}(req);
 
         // Verify token balances
-        assertEq(gasToken.balanceOf(vaultPC), initialGasTokenBalance + expectedGasFee);
+        assertEq(gasToken.balanceOf(vaultPC), initialGasTokenBalance + DEFAULT_PROTOCOL_FEE);
         assertEq(prc20Token.balanceOf(user1), initialPrc20Balance - amount);
     }
 
@@ -723,7 +727,7 @@ contract UniversalGatewayPCTest is Test {
         gateway.sendUniversalTxOutbound{value: PC_FEE}(req);
 
         // Verify token balances
-        assertEq(gasToken.balanceOf(vaultPC), initialGasTokenBalance + expectedGasFee);
+        assertEq(gasToken.balanceOf(vaultPC), initialGasTokenBalance + DEFAULT_PROTOCOL_FEE);
         assertEq(prc20Token.balanceOf(user1), initialPrc20Balance - amount);
     }
 
@@ -759,7 +763,7 @@ contract UniversalGatewayPCTest is Test {
         gateway.sendUniversalTxOutbound{value: PC_FEE}(req);
 
         // Verify token balances
-        assertEq(gasToken.balanceOf(vaultPC), initialGasTokenBalance + expectedGasFee);
+        assertEq(gasToken.balanceOf(vaultPC), initialGasTokenBalance + DEFAULT_PROTOCOL_FEE);
         assertEq(prc20Token.balanceOf(user1), initialPrc20Balance - amount);
     }
 
@@ -1025,7 +1029,7 @@ contract UniversalGatewayPCTest is Test {
         gateway.sendUniversalTxOutbound{value: PC_FEE}(req);
 
         // Verify withdrawal succeeded
-        assertEq(gasToken.balanceOf(vaultPC), initialGasTokenBalance + expectedGasFee);
+        assertEq(gasToken.balanceOf(vaultPC), initialGasTokenBalance + DEFAULT_PROTOCOL_FEE);
     }
 
     function testGasFeeCalculationAccuracy() public {
@@ -1057,7 +1061,7 @@ contract UniversalGatewayPCTest is Test {
         gateway.sendUniversalTxOutbound{value: PC_FEE}(req);
 
         uint256 balanceAfter = gasToken.balanceOf(vaultPC);
-        assertEq(balanceAfter - balanceBefore, expectedGasFee);
+        assertEq(balanceAfter - balanceBefore, DEFAULT_PROTOCOL_FEE);
 
         // Reset for next iteration
         prc20Token.mint(user1, amount);
@@ -1874,7 +1878,7 @@ contract UniversalGatewayPCTest is Test {
         gateway.sendUniversalTxOutbound{value: PC_FEE}(req);
 
         // Verify gas tokens were minted to vault via swap
-        assertEq(gasToken.balanceOf(vaultPC), initialGasBalance + expectedGasFee);
+        assertEq(gasToken.balanceOf(vaultPC), initialGasBalance + DEFAULT_PROTOCOL_FEE);
     }
 
     function testGasFee_GAS_AND_PAYLOAD_NotSupportedOnPC() public {
@@ -1901,7 +1905,7 @@ contract UniversalGatewayPCTest is Test {
 
         // Verify transaction succeeded and gas tokens were minted to vault via swap
         assertEq(gateway.nonce(), nonceBefore + 1, "Nonce should increment");
-        assertEq(gasToken.balanceOf(vaultPC), initialGasBalance + expectedGasFee, "Gas tokens should be minted to vault");
+        assertEq(gasToken.balanceOf(vaultPC), initialGasBalance + DEFAULT_PROTOCOL_FEE, "Only protocol fee should go to vault");
     }
 
     function testGasFee_FUNDS_AND_PAYLOAD_CorrectCalculation() public {
@@ -1927,7 +1931,7 @@ contract UniversalGatewayPCTest is Test {
         gateway.sendUniversalTxOutbound{value: PC_FEE}(req);
 
         // Verify gas tokens minted to vault via swap and PRC20 burned
-        assertEq(gasToken.balanceOf(vaultPC), initialGasBalance + expectedGasFee);
+        assertEq(gasToken.balanceOf(vaultPC), initialGasBalance + DEFAULT_PROTOCOL_FEE);
         assertEq(prc20Token.balanceOf(user1), initialPrc20Balance - amount);
     }
 
@@ -1979,7 +1983,7 @@ contract UniversalGatewayPCTest is Test {
         gateway.sendUniversalTxOutbound{value: PC_FEE}(req);
 
         // Verify DEFAULT_GAS_LIMIT was used for fee calculation
-        assertEq(gasToken.balanceOf(vaultPC), initialGasBalance + expectedGasFee);
+        assertEq(gasToken.balanceOf(vaultPC), initialGasBalance + DEFAULT_PROTOCOL_FEE);
     }
 
     function testStruct_EmptyPayloadBytes() public {
@@ -2293,14 +2297,14 @@ contract UniversalGatewayPCTest is Test {
             bytes(""), address(prc20Token), amount, DEFAULT_GAS_LIMIT, bytes(""), revertRecipient
         );
 
-        uint256 expectedGasFee = calculateExpectedGasFee(DEFAULT_GAS_LIMIT);
+        uint256 expectedTotal = calculateExpectedTotal(DEFAULT_GAS_LIMIT);
         uint256 userBalanceBefore = user1.balance;
 
         vm.prank(user1);
         gateway.sendUniversalTxOutbound{value: PC_FEE}(req);
 
-        // User gets refund: PC_FEE - gasFee (mock uses 1:1 PC-to-gasToken ratio)
-        uint256 expectedRefund = PC_FEE - expectedGasFee;
+        // User gets refund: PC_FEE - (gasFee + protocolFee) (mock uses 1:1 PC-to-gasToken ratio)
+        uint256 expectedRefund = PC_FEE - expectedTotal;
         assertEq(user1.balance, userBalanceBefore - PC_FEE + expectedRefund);
     }
 
@@ -2308,7 +2312,7 @@ contract UniversalGatewayPCTest is Test {
         uint256 amount = 1000 * 1e6;
         address revertRecipient = user2;
 
-        uint256 expectedGasFee = calculateExpectedGasFee(DEFAULT_GAS_LIMIT);
+        uint256 expectedTotal = calculateExpectedTotal(DEFAULT_GAS_LIMIT);
 
         UniversalOutboundTxRequest memory req = _createOutboundRequest(
             bytes(""), address(prc20Token), amount, DEFAULT_GAS_LIMIT, bytes(""), revertRecipient
@@ -2316,12 +2320,84 @@ contract UniversalGatewayPCTest is Test {
 
         uint256 userBalanceBefore = user1.balance;
 
-        // Send exactly gasFee as msg.value (no refund expected)
+        // Send exactly gasFee + protocolFee as msg.value (no refund expected)
         vm.prank(user1);
-        gateway.sendUniversalTxOutbound{value: expectedGasFee}(req);
+        gateway.sendUniversalTxOutbound{value: expectedTotal}(req);
 
-        // User spent exactly gasFee, no refund
-        assertEq(user1.balance, userBalanceBefore - expectedGasFee);
+        // User spent exactly total, no refund
+        assertEq(user1.balance, userBalanceBefore - expectedTotal);
+    }
+
+    // =========================
+    //  GAS TOKEN BURN VERIFICATION TESTS
+    // =========================
+
+    function testBurn_OnlyProtocolFeeInVault() public {
+        uint256 amount = 1000 * 1e6;
+        address revertRecipient = user2;
+
+        uint256 initialVaultBalance = gasToken.balanceOf(vaultPC);
+
+        UniversalOutboundTxRequest memory req = _createOutboundRequest(
+            bytes(""), address(prc20Token), amount, DEFAULT_GAS_LIMIT, bytes(""), revertRecipient
+        );
+
+        vm.prank(user1);
+        gateway.sendUniversalTxOutbound{value: PC_FEE}(req);
+
+        // Vault should only receive protocolFee, not gasFee
+        assertEq(gasToken.balanceOf(vaultPC), initialVaultBalance + DEFAULT_PROTOCOL_FEE);
+    }
+
+    function testBurn_GasTokenBurnedNotAccumulated() public {
+        uint256 amount = 1000 * 1e6;
+        address revertRecipient = user2;
+
+        uint256 supplyBefore = gasToken.totalSupply();
+        uint256 initialVaultBalance = gasToken.balanceOf(vaultPC);
+
+        UniversalOutboundTxRequest memory req = _createOutboundRequest(
+            bytes(""), address(prc20Token), amount, DEFAULT_GAS_LIMIT, bytes(""), revertRecipient
+        );
+
+        vm.prank(user1);
+        gateway.sendUniversalTxOutbound{value: PC_FEE}(req);
+
+        // gasFee was minted then burned — net supply change is only protocolFee (minted to vault)
+        assertEq(gasToken.totalSupply(), supplyBefore + DEFAULT_PROTOCOL_FEE);
+        // Vault only holds protocolFee
+        assertEq(gasToken.balanceOf(vaultPC), initialVaultBalance + DEFAULT_PROTOCOL_FEE);
+    }
+
+    function testBurn_ZeroProtocolFee_VaultGetsNothing() public {
+        // Deploy a token with zero protocol fee
+        MockPRC20 zeroFeeToken = new MockPRC20(
+            "Zero Fee Token",
+            "ZFT",
+            6,
+            SOURCE_CHAIN_NAMESPACE,
+            MockPRC20.TokenType.ERC20,
+            0, // zero protocol fee
+            address(universalCore),
+            SOURCE_TOKEN_ADDRESS
+        );
+
+        uint256 amount = 1000 * 1e6;
+        zeroFeeToken.mint(user1, amount);
+        vm.prank(user1);
+        zeroFeeToken.approve(address(gateway), amount);
+
+        uint256 initialVaultBalance = gasToken.balanceOf(vaultPC);
+
+        UniversalOutboundTxRequest memory req = _createOutboundRequest(
+            bytes(""), address(zeroFeeToken), amount, DEFAULT_GAS_LIMIT, bytes(""), user2
+        );
+
+        vm.prank(user1);
+        gateway.sendUniversalTxOutbound{value: PC_FEE}(req);
+
+        // Vault gets nothing when protocolFee is 0
+        assertEq(gasToken.balanceOf(vaultPC), initialVaultBalance);
     }
 
     function testRefund_ForwardFailure_Reverts() public {

--- a/contracts/evm-gateway/test/gateway/14_gatewayPC.t.sol
+++ b/contracts/evm-gateway/test/gateway/14_gatewayPC.t.sol
@@ -345,8 +345,7 @@ contract UniversalGatewayPCTest is Test {
             prc20Token.approve(address(gateway), amount);
         }
 
-        // Mock swap always outputs based on BASE_GAS_LIMIT (not custom gasLimit)
-        uint256 expectedSwapOut = calculateExpectedGasFee(DEFAULT_GAS_LIMIT);
+        uint256 expectedGasFee = calculateExpectedGasFee(gasLimit);
         uint256 initialGasTokenBalance = gasToken.balanceOf(vaultPC);
         uint256 initialPrc20Balance = prc20Token.balanceOf(user1);
 
@@ -362,8 +361,8 @@ contract UniversalGatewayPCTest is Test {
         vm.prank(user1);
         gateway.sendUniversalTxOutbound{value: PC_FEE}(req);
 
-        // Verify token balances (swap output based on BASE_GAS_LIMIT)
-        assertEq(gasToken.balanceOf(vaultPC), initialGasTokenBalance + expectedSwapOut);
+        // Verify token balances (exactOutputSingle mints exactly gasFee to vault)
+        assertEq(gasToken.balanceOf(vaultPC), initialGasTokenBalance + expectedGasFee);
         assertEq(prc20Token.balanceOf(user1), initialPrc20Balance - amount);
     }
 
@@ -586,8 +585,7 @@ contract UniversalGatewayPCTest is Test {
         bytes memory payload = abi.encodeWithSignature("transfer(address,uint256)", user2, 100);
         address revertRecipient = user2;
 
-        // Mock swap always outputs based on BASE_GAS_LIMIT (not custom gasLimit)
-        uint256 expectedSwapOut = calculateExpectedGasFee(DEFAULT_GAS_LIMIT);
+        uint256 expectedGasFee = calculateExpectedGasFee(gasLimit);
         uint256 initialGasTokenBalance = gasToken.balanceOf(vaultPC);
         uint256 initialPrc20Balance = prc20Token.balanceOf(user1);
 
@@ -603,8 +601,8 @@ contract UniversalGatewayPCTest is Test {
         vm.prank(user1);
         gateway.sendUniversalTxOutbound{value: PC_FEE}(req);
 
-        // Verify token balances (swap output based on BASE_GAS_LIMIT)
-        assertEq(gasToken.balanceOf(vaultPC), initialGasTokenBalance + expectedSwapOut);
+        // Verify token balances (exactOutputSingle mints exactly gasFee to vault)
+        assertEq(gasToken.balanceOf(vaultPC), initialGasTokenBalance + expectedGasFee);
         assertEq(prc20Token.balanceOf(user1), initialPrc20Balance - amount);
     }
 
@@ -1008,10 +1006,10 @@ contract UniversalGatewayPCTest is Test {
 
     function testMaxGasLimit() public {
         uint256 amount = 1000 * 1e6;
-        uint256 gasLimit = DEFAULT_GAS_LIMIT; // Use BASE_GAS_LIMIT (mock swap output matches quote at this limit)
+        uint256 gasLimit = DEFAULT_GAS_LIMIT;
         address revertRecipient = user2;
 
-        uint256 expectedSwapOut = calculateExpectedGasFee(DEFAULT_GAS_LIMIT);
+        uint256 expectedGasFee = calculateExpectedGasFee(gasLimit);
         uint256 initialGasTokenBalance = gasToken.balanceOf(vaultPC);
 
         UniversalOutboundTxRequest memory req = _createOutboundRequest(
@@ -1027,7 +1025,7 @@ contract UniversalGatewayPCTest is Test {
         gateway.sendUniversalTxOutbound{value: PC_FEE}(req);
 
         // Verify withdrawal succeeded
-        assertEq(gasToken.balanceOf(vaultPC), initialGasTokenBalance + expectedSwapOut);
+        assertEq(gasToken.balanceOf(vaultPC), initialGasTokenBalance + expectedGasFee);
     }
 
     function testGasFeeCalculationAccuracy() public {
@@ -1042,8 +1040,8 @@ contract UniversalGatewayPCTest is Test {
     }
 
     function _testGasFeeForLimit(uint256 amount, address revertRecipient, uint256 gasLimit) internal {
-        // Mock swap always outputs based on BASE_GAS_LIMIT regardless of requested gasLimit
-        uint256 expectedSwapOut = calculateExpectedGasFee(DEFAULT_GAS_LIMIT);
+        // exactOutputSingle mints exactly the quoted gasFee for the requested gasLimit
+        uint256 expectedGasFee = calculateExpectedGasFee(gasLimit);
         uint256 balanceBefore = gasToken.balanceOf(vaultPC);
 
         UniversalOutboundTxRequest memory req = _createOutboundRequest(
@@ -1059,7 +1057,7 @@ contract UniversalGatewayPCTest is Test {
         gateway.sendUniversalTxOutbound{value: PC_FEE}(req);
 
         uint256 balanceAfter = gasToken.balanceOf(vaultPC);
-        assertEq(balanceAfter - balanceBefore, expectedSwapOut);
+        assertEq(balanceAfter - balanceBefore, expectedGasFee);
 
         // Reset for next iteration
         prc20Token.mint(user1, amount);
@@ -1869,15 +1867,14 @@ contract UniversalGatewayPCTest is Test {
             revertRecipient
         );
 
-        // Mock swap output is always based on BASE_GAS_LIMIT
-        uint256 expectedSwapOut = calculateExpectedGasFee(DEFAULT_GAS_LIMIT);
+        uint256 expectedGasFee = calculateExpectedGasFee(gasLimit);
         uint256 initialGasBalance = gasToken.balanceOf(vaultPC);
 
         vm.prank(user1);
         gateway.sendUniversalTxOutbound{value: PC_FEE}(req);
 
         // Verify gas tokens were minted to vault via swap
-        assertEq(gasToken.balanceOf(vaultPC), initialGasBalance + expectedSwapOut);
+        assertEq(gasToken.balanceOf(vaultPC), initialGasBalance + expectedGasFee);
     }
 
     function testGasFee_GAS_AND_PAYLOAD_NotSupportedOnPC() public {
@@ -1895,8 +1892,7 @@ contract UniversalGatewayPCTest is Test {
             revertRecipient
         );
 
-        // Mock swap output is always based on BASE_GAS_LIMIT
-        uint256 expectedSwapOut = calculateExpectedGasFee(DEFAULT_GAS_LIMIT);
+        uint256 expectedGasFee = calculateExpectedGasFee(gasLimit);
         uint256 initialGasBalance = gasToken.balanceOf(vaultPC);
         uint256 nonceBefore = gateway.nonce();
 
@@ -1905,7 +1901,7 @@ contract UniversalGatewayPCTest is Test {
 
         // Verify transaction succeeded and gas tokens were minted to vault via swap
         assertEq(gateway.nonce(), nonceBefore + 1, "Nonce should increment");
-        assertEq(gasToken.balanceOf(vaultPC), initialGasBalance + expectedSwapOut, "Gas tokens should be minted to vault");
+        assertEq(gasToken.balanceOf(vaultPC), initialGasBalance + expectedGasFee, "Gas tokens should be minted to vault");
     }
 
     function testGasFee_FUNDS_AND_PAYLOAD_CorrectCalculation() public {
@@ -1923,8 +1919,7 @@ contract UniversalGatewayPCTest is Test {
             revertRecipient
         );
 
-        // Mock swap output is always based on BASE_GAS_LIMIT
-        uint256 expectedSwapOut = calculateExpectedGasFee(DEFAULT_GAS_LIMIT);
+        uint256 expectedGasFee = calculateExpectedGasFee(gasLimit);
         uint256 initialGasBalance = gasToken.balanceOf(vaultPC);
         uint256 initialPrc20Balance = prc20Token.balanceOf(user1);
 
@@ -1932,7 +1927,7 @@ contract UniversalGatewayPCTest is Test {
         gateway.sendUniversalTxOutbound{value: PC_FEE}(req);
 
         // Verify gas tokens minted to vault via swap and PRC20 burned
-        assertEq(gasToken.balanceOf(vaultPC), initialGasBalance + expectedSwapOut);
+        assertEq(gasToken.balanceOf(vaultPC), initialGasBalance + expectedGasFee);
         assertEq(prc20Token.balanceOf(user1), initialPrc20Balance - amount);
     }
 
@@ -2290,21 +2285,68 @@ contract UniversalGatewayPCTest is Test {
         assertEq(prc20Token.balanceOf(address(gateway)), 0);
     }
 
-    function testSwapFees_InsufficientSwapOutput_Reverts() public {
+    function testRefund_UserReceivesExcessPC() public {
         uint256 amount = 1000 * 1e6;
         address revertRecipient = user2;
 
-        // The mock swap outputs: gasPrice * BASE_GAS_LIMIT + protocolFee.
-        // The quote uses:        gasPrice * requestedGasLimit + protocolFee.
-        // When requestedGasLimit > BASE_GAS_LIMIT, the quoted gasFee exceeds swap output → revert.
-        uint256 highGasLimit = DEFAULT_GAS_LIMIT * 2; // 1M > 500k BASE_GAS_LIMIT
-
         UniversalOutboundTxRequest memory req = _createOutboundRequest(
-            bytes(""), address(prc20Token), amount, highGasLimit, bytes(""), revertRecipient
+            bytes(""), address(prc20Token), amount, DEFAULT_GAS_LIMIT, bytes(""), revertRecipient
         );
 
+        uint256 expectedGasFee = calculateExpectedGasFee(DEFAULT_GAS_LIMIT);
+        uint256 userBalanceBefore = user1.balance;
+
         vm.prank(user1);
-        vm.expectRevert(Errors.InsufficientProtocolFee.selector);
+        gateway.sendUniversalTxOutbound{value: PC_FEE}(req);
+
+        // User gets refund: PC_FEE - gasFee (mock uses 1:1 PC-to-gasToken ratio)
+        uint256 expectedRefund = PC_FEE - expectedGasFee;
+        assertEq(user1.balance, userBalanceBefore - PC_FEE + expectedRefund);
+    }
+
+    function testRefund_NoRefundWhenExactAmount() public {
+        uint256 amount = 1000 * 1e6;
+        address revertRecipient = user2;
+
+        uint256 expectedGasFee = calculateExpectedGasFee(DEFAULT_GAS_LIMIT);
+
+        UniversalOutboundTxRequest memory req = _createOutboundRequest(
+            bytes(""), address(prc20Token), amount, DEFAULT_GAS_LIMIT, bytes(""), revertRecipient
+        );
+
+        uint256 userBalanceBefore = user1.balance;
+
+        // Send exactly gasFee as msg.value (no refund expected)
+        vm.prank(user1);
+        gateway.sendUniversalTxOutbound{value: expectedGasFee}(req);
+
+        // User spent exactly gasFee, no refund
+        assertEq(user1.balance, userBalanceBefore - expectedGasFee);
+    }
+
+    function testRefund_ForwardFailure_Reverts() public {
+        uint256 amount = 1000 * 1e6;
+        address revertRecipient = user2;
+
+        // Deploy a contract that rejects ETH transfers
+        ETHRejecter rejecter = new ETHRejecter();
+        vm.deal(address(rejecter), 100 ether);
+        prc20Token.mint(address(rejecter), LARGE_AMOUNT);
+        vm.prank(address(rejecter));
+        prc20Token.approve(address(gateway), type(uint256).max);
+
+        UniversalOutboundTxRequest memory req = _createOutboundRequest(
+            bytes(""), address(prc20Token), amount, DEFAULT_GAS_LIMIT, bytes(""), revertRecipient
+        );
+
+        // Rejecter sends more than gasFee, so UniversalCore's refund to caller fails
+        vm.prank(address(rejecter));
+        vm.expectRevert("MockUniversalCore: refund failed");
         gateway.sendUniversalTxOutbound{value: PC_FEE}(req);
     }
+}
+
+/// @dev Helper contract that rejects native token transfers (for testing refund failure)
+contract ETHRejecter {
+    // No receive() or fallback() — rejects all ETH transfers
 }

--- a/contracts/evm-gateway/test/gateway/15_sendUniversalTxViaCEA.t.sol
+++ b/contracts/evm-gateway/test/gateway/15_sendUniversalTxViaCEA.t.sol
@@ -4,12 +4,7 @@ pragma solidity 0.8.26;
 import { BaseTest } from "../BaseTest.t.sol";
 import { Vm } from "forge-std/Vm.sol";
 import { UniversalGateway } from "../../src/UniversalGateway.sol";
-import {
-    TX_TYPE,
-    RevertInstructions,
-    UniversalPayload,
-    UniversalTxRequest
-} from "../../src/libraries/Types.sol";
+import { TX_TYPE, RevertInstructions, UniversalPayload, UniversalTxRequest } from "../../src/libraries/Types.sol";
 import { Errors } from "../../src/libraries/Errors.sol";
 import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import { MockCEAFactory } from "../mocks/MockCEAFactory.sol";
@@ -89,11 +84,11 @@ contract SendUniversalTxViaCEATest is BaseTest {
         return abi.encode(buildDefaultPayload());
     }
 
-    function _buildViaCEARequest(
-        address token,
-        uint256 amount,
-        bytes memory payload
-    ) internal view returns (UniversalTxRequest memory) {
+    function _buildViaCEARequest(address token, uint256 amount, bytes memory payload)
+        internal
+        view
+        returns (UniversalTxRequest memory)
+    {
         return UniversalTxRequest({
             recipient: mappedUEA,
             token: token,
@@ -113,9 +108,7 @@ contract SendUniversalTxViaCEATest is BaseTest {
         vm.store(address(gateway), bytes32(uint256(20)), bytes32(0));
         assertEq(gateway.CEA_FACTORY(), address(0));
 
-        UniversalTxRequest memory req = _buildViaCEARequest(
-            address(tokenA), 100 ether, _defaultPayload()
-        );
+        UniversalTxRequest memory req = _buildViaCEARequest(address(tokenA), 100 ether, _defaultPayload());
 
         vm.expectRevert(Errors.InvalidInput.selector);
         vm.prank(address(cea));
@@ -123,9 +116,7 @@ contract SendUniversalTxViaCEATest is BaseTest {
     }
 
     function test_RevertWhen_CallerIsNotACEA() public {
-        UniversalTxRequest memory req = _buildViaCEARequest(
-            address(tokenA), 100 ether, _defaultPayload()
-        );
+        UniversalTxRequest memory req = _buildViaCEARequest(address(tokenA), 100 ether, _defaultPayload());
 
         vm.expectRevert(Errors.InvalidInput.selector);
         vm.prank(attacker);
@@ -133,9 +124,7 @@ contract SendUniversalTxViaCEATest is BaseTest {
     }
 
     function test_RevertWhen_CallerIsEOA() public {
-        UniversalTxRequest memory req = _buildViaCEARequest(
-            address(tokenA), 100 ether, _defaultPayload()
-        );
+        UniversalTxRequest memory req = _buildViaCEARequest(address(tokenA), 100 ether, _defaultPayload());
 
         vm.expectRevert(Errors.InvalidInput.selector);
         vm.prank(user1);
@@ -147,7 +136,7 @@ contract SendUniversalTxViaCEATest is BaseTest {
     // =====================================================
 
     function test_RevertWhen_MappedUEAIsZero() public {
-        // Deploy a second factory that returns address(0) for getUEAForCEA
+        // Deploy a second factory that returns address(0) for getPushAccountForCEA
         MockCEAFactory badFactory = new MockCEAFactory();
         badFactory.setVault(address(this));
         // Deploy a CEA but then manipulate — use a fresh address not in mapping
@@ -156,9 +145,7 @@ contract SendUniversalTxViaCEATest is BaseTest {
         vm.prank(admin);
         gateway.setCEAFactory(address(badFactory));
 
-        UniversalTxRequest memory req = _buildViaCEARequest(
-            address(tokenA), 100 ether, _defaultPayload()
-        );
+        UniversalTxRequest memory req = _buildViaCEARequest(address(tokenA), 100 ether, _defaultPayload());
 
         // fakeCEA is not in the factory mapping → isCEA returns false
         vm.expectRevert(Errors.InvalidInput.selector);
@@ -225,9 +212,7 @@ contract SendUniversalTxViaCEATest is BaseTest {
         // amount=0, token=tokenA, payload=non-empty → GAS_AND_PAYLOAD
         // _sendTxWithGas called with gasAmount=0 → skips caps, just emits event
         // req.token field is ignored by _sendTxWithGas (always emits token=address(0))
-        UniversalTxRequest memory req = _buildViaCEARequest(
-            address(tokenA), 0, _defaultPayload()
-        );
+        UniversalTxRequest memory req = _buildViaCEARequest(address(tokenA), 0, _defaultPayload());
 
         vm.expectEmit(true, true, false, true, address(gateway));
         emit UniversalTx(
@@ -249,9 +234,7 @@ contract SendUniversalTxViaCEATest is BaseTest {
     function test_FUNDS_ViaCEA_ERC20_HappyPath() public {
         // amount=100, token=tokenA, payload=empty → TX_TYPE.FUNDS → now allowed via CEA
         uint256 amount = 100 ether;
-        UniversalTxRequest memory req = _buildViaCEARequest(
-            address(tokenA), amount, bytes("")
-        );
+        UniversalTxRequest memory req = _buildViaCEARequest(address(tokenA), amount, bytes(""));
 
         uint256 vaultBefore = tokenA.balanceOf(address(this));
 
@@ -277,23 +260,13 @@ contract SendUniversalTxViaCEATest is BaseTest {
     function test_FUNDS_ViaCEA_Native_HappyPath() public {
         // Native FUNDS: msg.value must equal req.amount exactly
         uint256 amount = 1 ether;
-        UniversalTxRequest memory req = _buildViaCEARequest(
-            address(0), amount, bytes("")
-        );
+        UniversalTxRequest memory req = _buildViaCEARequest(address(0), amount, bytes(""));
 
         uint256 tssBefore = tss.balance;
 
         vm.expectEmit(true, true, false, true, address(gateway));
         emit UniversalTx(
-            address(cea),
-            mappedUEA,
-            address(0),
-            amount,
-            bytes(""),
-            req.revertRecipient,
-            TX_TYPE.FUNDS,
-            bytes(""),
-            true
+            address(cea), mappedUEA, address(0), amount, bytes(""), req.revertRecipient, TX_TYPE.FUNDS, bytes(""), true
         );
 
         vm.prank(address(cea));
@@ -310,9 +283,7 @@ contract SendUniversalTxViaCEATest is BaseTest {
         uint256 amount = 100 ether;
         bytes memory payload = _defaultPayload();
 
-        UniversalTxRequest memory req = _buildViaCEARequest(
-            address(tokenA), amount, payload
-        );
+        UniversalTxRequest memory req = _buildViaCEARequest(address(tokenA), amount, payload);
 
         uint256 vaultBefore = tokenA.balanceOf(address(this)); // VAULT = address(this) in BaseTest
 
@@ -333,11 +304,7 @@ contract SendUniversalTxViaCEATest is BaseTest {
         gateway.sendUniversalTxFromCEA(req);
 
         // Vault received tokens
-        assertEq(
-            tokenA.balanceOf(address(this)),
-            vaultBefore + amount,
-            "Vault should receive ERC20"
-        );
+        assertEq(tokenA.balanceOf(address(this)), vaultBefore + amount, "Vault should receive ERC20");
     }
 
     function test_ERC20_RevertWhen_TokenNotSupported() public {
@@ -350,9 +317,7 @@ contract SendUniversalTxViaCEATest is BaseTest {
         vm.prank(admin);
         gateway.setTokenLimitThresholds(tokens, thresholds);
 
-        UniversalTxRequest memory req = _buildViaCEARequest(
-            address(tokenA), 100 ether, _defaultPayload()
-        );
+        UniversalTxRequest memory req = _buildViaCEARequest(address(tokenA), 100 ether, _defaultPayload());
 
         vm.expectRevert(Errors.NotSupported.selector);
         vm.prank(address(cea));
@@ -364,9 +329,7 @@ contract SendUniversalTxViaCEATest is BaseTest {
         vm.prank(address(cea));
         tokenA.approve(address(gateway), 0);
 
-        UniversalTxRequest memory req = _buildViaCEARequest(
-            address(tokenA), 100 ether, _defaultPayload()
-        );
+        UniversalTxRequest memory req = _buildViaCEARequest(address(tokenA), 100 ether, _defaultPayload());
 
         vm.expectRevert();
         vm.prank(address(cea));
@@ -381,9 +344,7 @@ contract SendUniversalTxViaCEATest is BaseTest {
         uint256 amount = 1 ether;
         bytes memory payload = _defaultPayload();
 
-        UniversalTxRequest memory req = _buildViaCEARequest(
-            address(0), amount, payload
-        );
+        UniversalTxRequest memory req = _buildViaCEARequest(address(0), amount, payload);
 
         uint256 tssBefore = tss.balance;
 
@@ -414,24 +375,14 @@ contract SendUniversalTxViaCEATest is BaseTest {
         uint256 totalValue = fundsAmount + gasTopUp;
         bytes memory payload = _defaultPayload();
 
-        UniversalTxRequest memory req = _buildViaCEARequest(
-            address(0), fundsAmount, payload
-        );
+        UniversalTxRequest memory req = _buildViaCEARequest(address(0), fundsAmount, payload);
 
         uint256 tssBefore = tss.balance;
 
         // Expect GAS leg event first (gasTopUp)
         vm.expectEmit(true, true, false, true, address(gateway));
         emit UniversalTx(
-            address(cea),
-            mappedUEA,
-            address(0),
-            gasTopUp,
-            bytes(""),
-            req.revertRecipient,
-            TX_TYPE.GAS,
-            bytes(""),
-            true
+            address(cea), mappedUEA, address(0), gasTopUp, bytes(""), req.revertRecipient, TX_TYPE.GAS, bytes(""), true
         );
         // Then FUNDS_AND_PAYLOAD event (fundsAmount)
         vm.expectEmit(true, true, false, true, address(gateway));
@@ -457,9 +408,7 @@ contract SendUniversalTxViaCEATest is BaseTest {
         uint256 amount = 2 ether;
         bytes memory payload = _defaultPayload();
 
-        UniversalTxRequest memory req = _buildViaCEARequest(
-            address(0), amount, payload
-        );
+        UniversalTxRequest memory req = _buildViaCEARequest(address(0), amount, payload);
 
         vm.expectRevert(Errors.InvalidAmount.selector);
         vm.prank(address(cea));
@@ -477,9 +426,7 @@ contract SendUniversalTxViaCEATest is BaseTest {
         uint256 gasAmount = 0.002 ether;
         bytes memory payload = _defaultPayload();
 
-        UniversalTxRequest memory req = _buildViaCEARequest(
-            address(tokenA), amount, payload
-        );
+        UniversalTxRequest memory req = _buildViaCEARequest(address(tokenA), amount, payload);
 
         uint256 vaultBefore = tokenA.balanceOf(address(this));
         uint256 tssBefore = tss.balance;
@@ -487,15 +434,7 @@ contract SendUniversalTxViaCEATest is BaseTest {
         // Expect GAS leg event first (gasAmount in native)
         vm.expectEmit(true, true, false, true, address(gateway));
         emit UniversalTx(
-            address(cea),
-            mappedUEA,
-            address(0),
-            gasAmount,
-            bytes(""),
-            req.revertRecipient,
-            TX_TYPE.GAS,
-            bytes(""),
-            true
+            address(cea), mappedUEA, address(0), gasAmount, bytes(""), req.revertRecipient, TX_TYPE.GAS, bytes(""), true
         );
         // Then FUNDS_AND_PAYLOAD event (ERC-20)
         vm.expectEmit(true, true, false, true, address(gateway));
@@ -523,9 +462,7 @@ contract SendUniversalTxViaCEATest is BaseTest {
         uint256 amount = 1 ether;
         bytes memory payload = _defaultPayload();
 
-        UniversalTxRequest memory req = _buildViaCEARequest(
-            address(0), amount, payload
-        );
+        UniversalTxRequest memory req = _buildViaCEARequest(address(0), amount, payload);
 
         uint256 tssBefore = tss.balance;
 
@@ -549,9 +486,7 @@ contract SendUniversalTxViaCEATest is BaseTest {
         vm.prank(admin);
         gateway.setTokenLimitThresholds(tokens, thresholds);
 
-        UniversalTxRequest memory req = _buildViaCEARequest(
-            address(tokenA), 100 ether, _defaultPayload()
-        );
+        UniversalTxRequest memory req = _buildViaCEARequest(address(tokenA), 100 ether, _defaultPayload());
 
         vm.expectRevert(Errors.RateLimitExceeded.selector);
         vm.prank(address(cea));
@@ -597,15 +532,15 @@ contract SendUniversalTxViaCEATest is BaseTest {
 
         vm.expectEmit(true, true, false, true, address(gateway));
         emit UniversalTx(
-            address(cea),       // sender = CEA
-            mappedUEA,          // recipient = mapped UEA (not address(0))
+            address(cea), // sender = CEA
+            mappedUEA, // recipient = mapped UEA (not address(0))
             address(tokenA),
             amount,
             payload,
             address(0x456),
             TX_TYPE.FUNDS_AND_PAYLOAD,
             sigData,
-            true                // fromCEA = true
+            true // fromCEA = true
         );
 
         vm.prank(address(cea));
@@ -634,7 +569,7 @@ contract SendUniversalTxViaCEATest is BaseTest {
             address(0x456),
             TX_TYPE.GAS,
             bytes(""),
-            false               // fromCEA = false
+            false // fromCEA = false
         );
 
         vm.prank(user1);
@@ -645,18 +580,14 @@ contract SendUniversalTxViaCEATest is BaseTest {
         uint256 amount = 50 ether;
         bytes memory payload = _defaultPayload();
 
-        UniversalTxRequest memory req = _buildViaCEARequest(
-            address(tokenA), amount, payload
-        );
+        UniversalTxRequest memory req = _buildViaCEARequest(address(tokenA), amount, payload);
 
         vm.recordLogs();
         vm.prank(address(cea));
         gateway.sendUniversalTxFromCEA(req);
 
         // Find the UniversalTx event and verify recipient != address(0)
-        bytes32 eventSig = keccak256(
-            "UniversalTx(address,address,address,uint256,bytes,address,uint8,bytes,bool)"
-        );
+        bytes32 eventSig = keccak256("UniversalTx(address,address,address,uint256,bytes,address,uint8,bytes,bool)");
 
         Vm.Log[] memory logs = vm.getRecordedLogs();
         bool found = false;
@@ -715,9 +646,7 @@ contract SendUniversalTxViaCEATest is BaseTest {
         uint256 amount = 200 ether;
         bytes memory payload = _defaultPayload();
 
-        UniversalTxRequest memory req = _buildViaCEARequest(
-            address(tokenA), amount, payload
-        );
+        UniversalTxRequest memory req = _buildViaCEARequest(address(tokenA), amount, payload);
 
         uint256 vaultBefore = tokenA.balanceOf(address(this));
 
@@ -737,11 +666,7 @@ contract SendUniversalTxViaCEATest is BaseTest {
         vm.prank(address(cea));
         gateway.sendUniversalTxFromCEA(req);
 
-        assertEq(
-            tokenA.balanceOf(address(this)),
-            vaultBefore + amount,
-            "Vault received ERC20"
-        );
+        assertEq(tokenA.balanceOf(address(this)), vaultBefore + amount, "Vault received ERC20");
     }
 
     function test_E2E_Native_FundsAndPayload_NoBatching_ViaCEA() public {
@@ -749,9 +674,7 @@ contract SendUniversalTxViaCEATest is BaseTest {
         uint256 fundsAmount = 5 ether;
         bytes memory payload = _defaultPayload();
 
-        UniversalTxRequest memory req = _buildViaCEARequest(
-            address(0), fundsAmount, payload
-        );
+        UniversalTxRequest memory req = _buildViaCEARequest(address(0), fundsAmount, payload);
 
         uint256 tssBefore = tss.balance;
 
@@ -762,9 +685,7 @@ contract SendUniversalTxViaCEATest is BaseTest {
     }
 
     function test_E2E_InvalidCEA_Reverts() public {
-        UniversalTxRequest memory req = _buildViaCEARequest(
-            address(tokenA), 100 ether, _defaultPayload()
-        );
+        UniversalTxRequest memory req = _buildViaCEARequest(address(tokenA), 100 ether, _defaultPayload());
 
         // Attacker is not a CEA
         vm.expectRevert(Errors.InvalidInput.selector);
@@ -780,31 +701,20 @@ contract SendUniversalTxViaCEATest is BaseTest {
         uint256 amount = 100 ether;
         bytes memory payload = _defaultPayload();
 
-        UniversalTxRequest memory req = _buildViaCEARequest(
-            address(tokenA), amount, payload
-        );
+        UniversalTxRequest memory req = _buildViaCEARequest(address(tokenA), amount, payload);
 
         vm.recordLogs();
         vm.prank(address(cea));
         gateway.sendUniversalTxFromCEA(req);
 
-        bytes32 eventSig = keccak256(
-            "UniversalTx(address,address,address,uint256,bytes,address,uint8,bytes,bool)"
-        );
+        bytes32 eventSig = keccak256("UniversalTx(address,address,address,uint256,bytes,address,uint8,bytes,bool)");
 
         Vm.Log[] memory logs = vm.getRecordedLogs();
         for (uint256 i = 0; i < logs.length; i++) {
             if (logs[i].topics[0] == eventSig) {
                 address emittedRecipient = address(uint160(uint256(logs[i].topics[2])));
-                assertTrue(
-                    emittedRecipient != address(0),
-                    "REGRESSION: fromCEA must never emit recipient=address(0)"
-                );
-                assertEq(
-                    emittedRecipient,
-                    mappedUEA,
-                    "REGRESSION: recipient must be mapped UEA"
-                );
+                assertTrue(emittedRecipient != address(0), "REGRESSION: fromCEA must never emit recipient=address(0)");
+                assertEq(emittedRecipient, mappedUEA, "REGRESSION: recipient must be mapped UEA");
                 return;
             }
         }
@@ -829,19 +739,13 @@ contract SendUniversalTxViaCEATest is BaseTest {
         vm.prank(user1);
         gateway.sendUniversalTx(req);
 
-        bytes32 eventSig = keccak256(
-            "UniversalTx(address,address,address,uint256,bytes,address,uint8,bytes,bool)"
-        );
+        bytes32 eventSig = keccak256("UniversalTx(address,address,address,uint256,bytes,address,uint8,bytes,bool)");
 
         Vm.Log[] memory logs = vm.getRecordedLogs();
         for (uint256 i = 0; i < logs.length; i++) {
             if (logs[i].topics[0] == eventSig) {
                 address emittedRecipient = address(uint160(uint256(logs[i].topics[2])));
-                assertEq(
-                    emittedRecipient,
-                    address(0),
-                    "Non-fromCEA FUNDS_AND_PAYLOAD must keep recipient=address(0)"
-                );
+                assertEq(emittedRecipient, address(0), "Non-fromCEA FUNDS_AND_PAYLOAD must keep recipient=address(0)");
                 return;
             }
         }
@@ -856,9 +760,7 @@ contract SendUniversalTxViaCEATest is BaseTest {
         vm.prank(admin);
         gateway.pause();
 
-        UniversalTxRequest memory req = _buildViaCEARequest(
-            address(tokenA), 100 ether, _defaultPayload()
-        );
+        UniversalTxRequest memory req = _buildViaCEARequest(address(tokenA), 100 ether, _defaultPayload());
 
         vm.expectRevert();
         vm.prank(address(cea));
@@ -873,9 +775,7 @@ contract SendUniversalTxViaCEATest is BaseTest {
         uint256 gasAmount = 0.002 ether;
         bytes memory payload = _defaultPayload();
 
-        UniversalTxRequest memory req = _buildViaCEARequest(
-            address(0), 0, payload
-        );
+        UniversalTxRequest memory req = _buildViaCEARequest(address(0), 0, payload);
 
         uint256 tssBefore = tss.balance;
 
@@ -901,23 +801,13 @@ contract SendUniversalTxViaCEATest is BaseTest {
     function test_GasAndPayload_ViaCEA_PayloadOnly_NoGas_HappyPath() public {
         bytes memory payload = _defaultPayload();
 
-        UniversalTxRequest memory req = _buildViaCEARequest(
-            address(0), 0, payload
-        );
+        UniversalTxRequest memory req = _buildViaCEARequest(address(0), 0, payload);
 
         uint256 tssBefore = tss.balance;
 
         vm.expectEmit(true, true, false, true, address(gateway));
         emit UniversalTx(
-            address(cea),
-            mappedUEA,
-            address(0),
-            0,
-            payload,
-            address(0x456),
-            TX_TYPE.GAS_AND_PAYLOAD,
-            bytes(""),
-            true
+            address(cea), mappedUEA, address(0), 0, payload, address(0x456), TX_TYPE.GAS_AND_PAYLOAD, bytes(""), true
         );
 
         vm.prank(address(cea));
@@ -934,9 +824,7 @@ contract SendUniversalTxViaCEATest is BaseTest {
         // amount=0, token=tokenA, payload=non-empty → GAS_AND_PAYLOAD
         // _sendTxWithGas called with gasAmount=0 → skips caps, just emits
         // req.token field is ignored by _sendTxWithGas (token=address(0) in event)
-        UniversalTxRequest memory req = _buildViaCEARequest(
-            address(tokenA), 0, _defaultPayload()
-        );
+        UniversalTxRequest memory req = _buildViaCEARequest(address(tokenA), 0, _defaultPayload());
 
         vm.expectEmit(true, true, false, true, address(gateway));
         emit UniversalTx(
@@ -959,23 +847,13 @@ contract SendUniversalTxViaCEATest is BaseTest {
         // amount=0, token=address(0), payload=empty, msg.value>0 → GAS
         // GAS is now allowed via CEA
         uint256 gasAmount = 0.002 ether;
-        UniversalTxRequest memory req = _buildViaCEARequest(
-            address(0), 0, bytes("")
-        );
+        UniversalTxRequest memory req = _buildViaCEARequest(address(0), 0, bytes(""));
 
         uint256 tssBefore = tss.balance;
 
         vm.expectEmit(true, true, false, true, address(gateway));
         emit UniversalTx(
-            address(cea),
-            mappedUEA,
-            address(0),
-            gasAmount,
-            bytes(""),
-            req.revertRecipient,
-            TX_TYPE.GAS,
-            bytes(""),
-            true
+            address(cea), mappedUEA, address(0), gasAmount, bytes(""), req.revertRecipient, TX_TYPE.GAS, bytes(""), true
         );
 
         vm.prank(address(cea));
@@ -1025,9 +903,7 @@ contract SendUniversalTxViaCEATest is BaseTest {
         uint256 tinyGas = 0.0001 ether; // ~$0.20 at $2000/ETH, below $1 min
         bytes memory payload = _defaultPayload();
 
-        UniversalTxRequest memory req = _buildViaCEARequest(
-            address(0), 0, payload
-        );
+        UniversalTxRequest memory req = _buildViaCEARequest(address(0), 0, payload);
 
         vm.expectRevert(Errors.InvalidAmount.selector);
         vm.prank(address(cea));
@@ -1043,9 +919,7 @@ contract SendUniversalTxViaCEATest is BaseTest {
         uint256 gasAmount = 0.002 ether;
         bytes memory payload = _defaultPayload();
 
-        UniversalTxRequest memory req = _buildViaCEARequest(
-            address(0), 0, payload
-        );
+        UniversalTxRequest memory req = _buildViaCEARequest(address(0), 0, payload);
 
         vm.expectRevert(Errors.BlockCapLimitExceeded.selector);
         vm.prank(address(cea));
@@ -1059,9 +933,7 @@ contract SendUniversalTxViaCEATest is BaseTest {
         setCaps(1000e18, 2000e18); // $1000-$2000 range
 
         bytes memory payload = _defaultPayload();
-        UniversalTxRequest memory req = _buildViaCEARequest(
-            address(0), 0, payload
-        );
+        UniversalTxRequest memory req = _buildViaCEARequest(address(0), 0, payload);
 
         // Should succeed — caps skipped when gasAmount=0
         vm.prank(address(cea));
@@ -1074,17 +946,13 @@ contract SendUniversalTxViaCEATest is BaseTest {
 
     function test_GasAndPayload_ViaCEA_EventRecipientIsNeverZero() public {
         bytes memory payload = _defaultPayload();
-        UniversalTxRequest memory req = _buildViaCEARequest(
-            address(0), 0, payload
-        );
+        UniversalTxRequest memory req = _buildViaCEARequest(address(0), 0, payload);
 
         vm.recordLogs();
         vm.prank(address(cea));
         gateway.sendUniversalTxFromCEA{ value: 0.002 ether }(req);
 
-        bytes32 eventSig = keccak256(
-            "UniversalTx(address,address,address,uint256,bytes,address,uint8,bytes,bool)"
-        );
+        bytes32 eventSig = keccak256("UniversalTx(address,address,address,uint256,bytes,address,uint8,bytes,bool)");
 
         Vm.Log[] memory logs = vm.getRecordedLogs();
         bool found = false;
@@ -1115,15 +983,7 @@ contract SendUniversalTxViaCEATest is BaseTest {
 
         vm.expectEmit(true, true, false, true, address(gateway));
         emit UniversalTx(
-            user1,
-            address(0),
-            address(0),
-            gasAmount,
-            payload,
-            address(0x456),
-            TX_TYPE.GAS_AND_PAYLOAD,
-            bytes(""),
-            false
+            user1, address(0), address(0), gasAmount, payload, address(0x456), TX_TYPE.GAS_AND_PAYLOAD, bytes(""), false
         );
 
         vm.prank(user1);
@@ -1158,23 +1018,13 @@ contract SendUniversalTxViaCEATest is BaseTest {
         // amount=0, token=address(0), payload=empty, msg.value>0 → GAS
         // GAS is now allowed via CEA
         uint256 gasAmount = 0.002 ether;
-        UniversalTxRequest memory req = _buildViaCEARequest(
-            address(0), 0, bytes("")
-        );
+        UniversalTxRequest memory req = _buildViaCEARequest(address(0), 0, bytes(""));
 
         uint256 tssBefore = tss.balance;
 
         vm.expectEmit(true, true, false, true, address(gateway));
         emit UniversalTx(
-            address(cea),
-            mappedUEA,
-            address(0),
-            gasAmount,
-            bytes(""),
-            req.revertRecipient,
-            TX_TYPE.GAS,
-            bytes(""),
-            true
+            address(cea), mappedUEA, address(0), gasAmount, bytes(""), req.revertRecipient, TX_TYPE.GAS, bytes(""), true
         );
 
         vm.prank(address(cea));
@@ -1188,9 +1038,7 @@ contract SendUniversalTxViaCEATest is BaseTest {
         // Post-fee nativeValue > 0 is routed as a gas top-up to the CEA's mapped UEA.
         // CEA path skips protocol fee, so full amount becomes gas.
         uint256 gasTopUp = 0.003 ether; // ~$6 at $2000/ETH, within $1-$10 USD cap
-        UniversalTxRequest memory req = _buildViaCEARequest(
-            address(tokenA), 100 ether, bytes("")
-        );
+        UniversalTxRequest memory req = _buildViaCEARequest(address(tokenA), 100 ether, bytes(""));
 
         uint256 tssBalBefore = tss.balance;
 
@@ -1202,9 +1050,7 @@ contract SendUniversalTxViaCEATest is BaseTest {
 
     function test_FUNDS_ViaCEA_Native_RevertWhen_MsgValueMismatch() public {
         // Native FUNDS: msg.value must exactly equal req.amount
-        UniversalTxRequest memory req = _buildViaCEARequest(
-            address(0), 2 ether, bytes("")
-        );
+        UniversalTxRequest memory req = _buildViaCEARequest(address(0), 2 ether, bytes(""));
 
         vm.expectRevert(Errors.InvalidAmount.selector);
         vm.prank(address(cea));
@@ -1338,9 +1184,7 @@ contract SendUniversalTxViaCEATest is BaseTest {
         vm.prank(admin);
         gateway.setTokenLimitThresholds(tokens, thresholds);
 
-        UniversalTxRequest memory req = _buildViaCEARequest(
-            address(tokenA), 100 ether, bytes("")
-        );
+        UniversalTxRequest memory req = _buildViaCEARequest(address(tokenA), 100 ether, bytes(""));
 
         vm.expectRevert(Errors.RateLimitExceeded.selector);
         vm.prank(address(cea));
@@ -1349,17 +1193,13 @@ contract SendUniversalTxViaCEATest is BaseTest {
 
     function test_FUNDS_ViaCEA_EventRecipientIsNeverZero() public {
         uint256 amount = 50 ether;
-        UniversalTxRequest memory req = _buildViaCEARequest(
-            address(tokenA), amount, bytes("")
-        );
+        UniversalTxRequest memory req = _buildViaCEARequest(address(tokenA), amount, bytes(""));
 
         vm.recordLogs();
         vm.prank(address(cea));
         gateway.sendUniversalTxFromCEA(req);
 
-        bytes32 eventSig = keccak256(
-            "UniversalTx(address,address,address,uint256,bytes,address,uint8,bytes,bool)"
-        );
+        bytes32 eventSig = keccak256("UniversalTx(address,address,address,uint256,bytes,address,uint8,bytes,bool)");
 
         Vm.Log[] memory logs = vm.getRecordedLogs();
         bool found = false;
@@ -1377,17 +1217,13 @@ contract SendUniversalTxViaCEATest is BaseTest {
 
     function test_FUNDS_ViaCEA_EventViaCEA_True() public {
         uint256 amount = 50 ether;
-        UniversalTxRequest memory req = _buildViaCEARequest(
-            address(tokenA), amount, bytes("")
-        );
+        UniversalTxRequest memory req = _buildViaCEARequest(address(tokenA), amount, bytes(""));
 
         vm.recordLogs();
         vm.prank(address(cea));
         gateway.sendUniversalTxFromCEA(req);
 
-        bytes32 eventSig = keccak256(
-            "UniversalTx(address,address,address,uint256,bytes,address,uint8,bytes,bool)"
-        );
+        bytes32 eventSig = keccak256("UniversalTx(address,address,address,uint256,bytes,address,uint8,bytes,bool)");
 
         Vm.Log[] memory logs = vm.getRecordedLogs();
         bool found = false;
@@ -1402,10 +1238,7 @@ contract SendUniversalTxViaCEATest is BaseTest {
                     TX_TYPE txType,
                     bytes memory sigData,
                     bool fromCEA
-                ) = abi.decode(
-                    logs[i].data,
-                    (address, uint256, bytes, address, TX_TYPE, bytes, bool)
-                );
+                ) = abi.decode(logs[i].data, (address, uint256, bytes, address, TX_TYPE, bytes, bool));
                 assertTrue(fromCEA, "fromCEA must be true for FUNDS via CEA");
                 assertEq(uint8(txType), uint8(TX_TYPE.FUNDS), "txType must be FUNDS");
                 assertEq(token, address(tokenA), "token must be tokenA");
@@ -1433,18 +1266,14 @@ contract SendUniversalTxViaCEATest is BaseTest {
         vm.prank(user1);
         gateway.sendUniversalTx(req);
 
-        bytes32 eventSig = keccak256(
-            "UniversalTx(address,address,address,uint256,bytes,address,uint8,bytes,bool)"
-        );
+        bytes32 eventSig = keccak256("UniversalTx(address,address,address,uint256,bytes,address,uint8,bytes,bool)");
 
         Vm.Log[] memory logs = vm.getRecordedLogs();
         bool found = false;
         for (uint256 i = 0; i < logs.length; i++) {
             if (logs[i].topics[0] == eventSig) {
-                (,,,,,, bool fromCEA) = abi.decode(
-                    logs[i].data,
-                    (address, uint256, bytes, address, TX_TYPE, bytes, bool)
-                );
+                (,,,,,, bool fromCEA) =
+                    abi.decode(logs[i].data, (address, uint256, bytes, address, TX_TYPE, bytes, bool));
                 assertFalse(fromCEA, "Non-fromCEA FUNDS must emit fromCEA=false");
                 found = true;
                 break;
@@ -1473,15 +1302,7 @@ contract SendUniversalTxViaCEATest is BaseTest {
         // Expect GAS leg: fromCEA=false, recipient=address(0)
         vm.expectEmit(true, true, false, true, address(gateway));
         emit UniversalTx(
-            user1,
-            address(0),
-            address(0),
-            gasTopUp,
-            bytes(""),
-            address(0x456),
-            TX_TYPE.GAS,
-            bytes(""),
-            false
+            user1, address(0), address(0), gasTopUp, bytes(""), address(0x456), TX_TYPE.GAS, bytes(""), false
         );
         // Expect FUNDS_AND_PAYLOAD leg: fromCEA=false, recipient=address(0)
         vm.expectEmit(true, true, false, true, address(gateway));
@@ -1500,5 +1321,4 @@ contract SendUniversalTxViaCEATest is BaseTest {
         vm.prank(user1);
         gateway.sendUniversalTx{ value: totalValue }(req);
     }
-
 }

--- a/contracts/evm-gateway/test/mocks/MockCEAFactory.sol
+++ b/contracts/evm-gateway/test/mocks/MockCEAFactory.sol
@@ -132,7 +132,7 @@ contract MockCEAFactory is ICEAFactory {
     }
 
     /// @inheritdoc ICEAFactory
-    function getUEAForCEA(address _cea) external view override returns (address uea) {
+    function getPushAccountForCEA(address _cea) external view override returns (address uea) {
         return CEA_to_UEA[_cea];
     }
 
@@ -148,26 +148,13 @@ contract MockCEAFactory is ICEAFactory {
     function _computeCEAInternal(address ueaOnPush) internal view returns (address) {
         // Use similar salt generation as real CEAFactory
         bytes32 salt = _generateSalt(ueaOnPush);
-        
+
         // In real contract, this uses Clones.predictDeterministicAddress
         // For mock, we compute a deterministic address based on salt and factory address
         // This mimics CREATE2 behavior without circular reference
         // Using a fixed bytecode hash to avoid circular reference
         bytes32 bytecodeHash = keccak256(abi.encodePacked("MOCK_CEA_PROXY"));
-        return address(
-            uint160(
-                uint256(
-                    keccak256(
-                        abi.encodePacked(
-                            bytes1(0xff),
-                            address(this),
-                            salt,
-                            bytecodeHash
-                        )
-                    )
-                )
-            )
-        );
+        return address(uint160(uint256(keccak256(abi.encodePacked(bytes1(0xff), address(this), salt, bytecodeHash)))));
     }
 
     function _generateSalt(address ueaOnPush) internal pure returns (bytes32) {

--- a/contracts/evm-gateway/test/mocks/MockPRC20.sol
+++ b/contracts/evm-gateway/test/mocks/MockPRC20.sol
@@ -170,7 +170,7 @@ contract MockPRC20 is IPRC20 {
         view
         returns (address gasToken, uint256 gasFee, uint256 protocolFee, string memory chainNamespace)
     {
-        return IUniversalCore(UNIVERSAL_CORE).withdrawGasFeeWithGasLimit(address(this), gasLimit);
+        return IUniversalCore(UNIVERSAL_CORE).getOutboundTxGasAndFees(address(this), gasLimit);
     }
 
     //*** ADMIN FUNCTIONS ***//

--- a/contracts/evm-gateway/test/mocks/MockPRC20.sol
+++ b/contracts/evm-gateway/test/mocks/MockPRC20.sol
@@ -165,7 +165,11 @@ contract MockPRC20 is IPRC20 {
     }
 
     /// @notice Get gas fee with custom gas limit (delegates to UniversalCore)
-    function withdrawGasFeeWithGasLimit(uint256 gasLimit) external view returns (address gasToken, uint256 gasFee) {
+    function withdrawGasFeeWithGasLimit(uint256 gasLimit)
+        external
+        view
+        returns (address gasToken, uint256 gasFee, uint256 protocolFee, string memory chainNamespace)
+    {
         return IUniversalCore(UNIVERSAL_CORE).withdrawGasFeeWithGasLimit(address(this), gasLimit);
     }
 

--- a/contracts/evm-gateway/test/mocks/MockPRC20.sol
+++ b/contracts/evm-gateway/test/mocks/MockPRC20.sol
@@ -168,7 +168,7 @@ contract MockPRC20 is IPRC20 {
     function withdrawGasFeeWithGasLimit(uint256 gasLimit)
         external
         view
-        returns (address gasToken, uint256 gasFee, uint256 protocolFee, string memory chainNamespace)
+        returns (address gasToken, uint256 gasFee, uint256 protocolFee, uint256 gasPrice, string memory chainNamespace)
     {
         return IUniversalCore(UNIVERSAL_CORE).getOutboundTxGasAndFees(address(this), gasLimit);
     }

--- a/contracts/evm-gateway/test/mocks/MockReentrantContract.sol
+++ b/contracts/evm-gateway/test/mocks/MockReentrantContract.sol
@@ -32,7 +32,7 @@ contract MockReentrantContract {
     // UniversalGatewayPC Reentrancy Functions
     // ============================================================================
 
-    function attemptReentrancy(uint256 amount, uint256 gasLimit, address revertRecipient) external {
+    function attemptReentrancy(uint256 amount, uint256 gasLimit, address revertRecipient) external payable {
         UniversalOutboundTxRequest memory req = UniversalOutboundTxRequest({
             recipient: bytes(""),
             token: prc20Token,
@@ -41,7 +41,7 @@ contract MockReentrantContract {
             payload: bytes(""), // empty payload for FUNDS type
             revertRecipient: revertRecipient
         });
-        IUniversalGatewayPC(gateway).sendUniversalTxOutbound(req);
+        IUniversalGatewayPC(gateway).sendUniversalTxOutbound{value: msg.value}(req);
     }
 
     function attemptReentrancyWithExecute(
@@ -49,7 +49,7 @@ contract MockReentrantContract {
         bytes calldata payload,
         uint256 gasLimit,
         address revertRecipient
-    ) external {
+    ) external payable {
         UniversalOutboundTxRequest memory req = UniversalOutboundTxRequest({
             recipient: bytes(""),
             token: prc20Token,
@@ -58,8 +58,10 @@ contract MockReentrantContract {
             payload: payload, // non-empty payload for FUNDS_AND_PAYLOAD type
             revertRecipient: revertRecipient
         });
-        IUniversalGatewayPC(gateway).sendUniversalTxOutbound(req);
+        IUniversalGatewayPC(gateway).sendUniversalTxOutbound{value: msg.value}(req);
     }
+
+    receive() external payable {}
 
     // ============================================================================
     // Vault Reentrancy Functions

--- a/contracts/evm-gateway/test/mocks/MockUniversalCoreReal.sol
+++ b/contracts/evm-gateway/test/mocks/MockUniversalCoreReal.sol
@@ -292,14 +292,25 @@ contract MockUniversalCoreReal is IUniversalCore {
         address prc20,
         address vault,
         uint24,
+        uint256 requiredGasTokenOut,
         uint256,
-        uint256
-    ) external payable returns (uint256 gasTokenOut) {
+        address caller
+    ) external payable returns (uint256 gasTokenOut, uint256 refund) {
+        require(requiredGasTokenOut > 0, "MockUniversalCore: zero required output");
+
         string memory ns = IPRC20(prc20).SOURCE_CHAIN_NAMESPACE();
         address gasTokenAddr = gasTokenPRC20ByChainNamespace[ns];
-        gasTokenOut = gasPriceByChainNamespace[ns] * BASE_GAS_LIMIT
-            + IPRC20(prc20).PC_PROTOCOL_FEE();
+
+        // Mint exactly requiredGasTokenOut to vault (simulates exactOutputSingle)
+        gasTokenOut = requiredGasTokenOut;
         MockPRC20(gasTokenAddr).mint(vault, gasTokenOut);
+
+        // Refund unused PC directly to the caller
+        if (msg.value > gasTokenOut) {
+            refund = msg.value - gasTokenOut;
+            (bool ok,) = caller.call{value: refund}("");
+            require(ok, "MockUniversalCore: refund failed");
+        }
     }
 
     receive() external payable {}

--- a/contracts/evm-gateway/test/mocks/MockUniversalCoreReal.sol
+++ b/contracts/evm-gateway/test/mocks/MockUniversalCoreReal.sol
@@ -254,17 +254,17 @@ contract MockUniversalCoreReal is IUniversalCore {
     function getOutboundTxGasAndFees(address _prc20, uint256 gasLimit)
         public
         view
-        returns (address gasToken, uint256 gasFee, uint256 protocolFee, string memory chainNamespace)
+        returns (address gasToken, uint256 gasFee, uint256 protocolFee, uint256 gasPrice, string memory chainNamespace)
     {
         chainNamespace = IPRC20(_prc20).SOURCE_CHAIN_NAMESPACE();
 
         gasToken = gasTokenPRC20ByChainNamespace[chainNamespace];
         require(gasToken != address(0), "MockUniversalCore: zero gas token");
 
-        uint256 price = gasPriceByChainNamespace[chainNamespace];
-        require(price != 0, "MockUniversalCore: zero gas price");
+        gasPrice = gasPriceByChainNamespace[chainNamespace];
+        require(gasPrice != 0, "MockUniversalCore: zero gas price");
 
-        gasFee = price * gasLimit;
+        gasFee = gasPrice * gasLimit;
         protocolFee = IPRC20(_prc20).PC_PROTOCOL_FEE();
     }
 

--- a/contracts/evm-gateway/test/mocks/MockUniversalCoreReal.sol
+++ b/contracts/evm-gateway/test/mocks/MockUniversalCoreReal.sol
@@ -251,24 +251,7 @@ contract MockUniversalCoreReal is IUniversalCore {
         return amountIn;
     }
 
-    function withdrawGasFee(address _prc20)
-        public
-        view
-        returns (address gasToken, uint256 gasFee, uint256 protocolFee, string memory chainNamespace)
-    {
-        chainNamespace = IPRC20(_prc20).SOURCE_CHAIN_NAMESPACE();
-
-        gasToken = gasTokenPRC20ByChainNamespace[chainNamespace];
-        require(gasToken != address(0), "MockUniversalCore: zero gas token");
-
-        uint256 price = gasPriceByChainNamespace[chainNamespace];
-        require(price != 0, "MockUniversalCore: zero gas price");
-
-        gasFee = price * BASE_GAS_LIMIT;
-        protocolFee = IPRC20(_prc20).PC_PROTOCOL_FEE();
-    }
-
-    function withdrawGasFeeWithGasLimit(address _prc20, uint256 gasLimit)
+    function getOutboundTxGasAndFees(address _prc20, uint256 gasLimit)
         public
         view
         returns (address gasToken, uint256 gasFee, uint256 protocolFee, string memory chainNamespace)

--- a/contracts/evm-gateway/test/mocks/MockUniversalCoreReal.sol
+++ b/contracts/evm-gateway/test/mocks/MockUniversalCoreReal.sol
@@ -251,32 +251,38 @@ contract MockUniversalCoreReal is IUniversalCore {
         return amountIn;
     }
 
-    function withdrawGasFee(address _prc20) public view returns (address gasToken, uint256 gasFee) {
-        string memory chainID = IPRC20(_prc20).SOURCE_CHAIN_NAMESPACE();
+    function withdrawGasFee(address _prc20)
+        public
+        view
+        returns (address gasToken, uint256 gasFee, uint256 protocolFee, string memory chainNamespace)
+    {
+        chainNamespace = IPRC20(_prc20).SOURCE_CHAIN_NAMESPACE();
 
-        gasToken = gasTokenPRC20ByChainNamespace[chainID];
+        gasToken = gasTokenPRC20ByChainNamespace[chainNamespace];
         require(gasToken != address(0), "MockUniversalCore: zero gas token");
 
-        uint256 price = gasPriceByChainNamespace[chainID];
+        uint256 price = gasPriceByChainNamespace[chainNamespace];
         require(price != 0, "MockUniversalCore: zero gas price");
 
-        gasFee = price * BASE_GAS_LIMIT + IPRC20(_prc20).PC_PROTOCOL_FEE();
+        gasFee = price * BASE_GAS_LIMIT;
+        protocolFee = IPRC20(_prc20).PC_PROTOCOL_FEE();
     }
 
     function withdrawGasFeeWithGasLimit(address _prc20, uint256 gasLimit)
         public
         view
-        returns (address gasToken, uint256 gasFee)
+        returns (address gasToken, uint256 gasFee, uint256 protocolFee, string memory chainNamespace)
     {
-        string memory chainID = IPRC20(_prc20).SOURCE_CHAIN_NAMESPACE();
+        chainNamespace = IPRC20(_prc20).SOURCE_CHAIN_NAMESPACE();
 
-        gasToken = gasTokenPRC20ByChainNamespace[chainID];
+        gasToken = gasTokenPRC20ByChainNamespace[chainNamespace];
         require(gasToken != address(0), "MockUniversalCore: zero gas token");
 
-        uint256 price = gasPriceByChainNamespace[chainID];
+        uint256 price = gasPriceByChainNamespace[chainNamespace];
         require(price != 0, "MockUniversalCore: zero gas price");
 
-        gasFee = price * gasLimit + IPRC20(_prc20).PC_PROTOCOL_FEE();
+        gasFee = price * gasLimit;
+        protocolFee = IPRC20(_prc20).PC_PROTOCOL_FEE();
     }
 
     /// @notice Update the base gas limit for the cross-chain outbound transactions.
@@ -288,26 +294,34 @@ contract MockUniversalCoreReal is IUniversalCore {
     }
 
     // ========= Swap Functions =========
-    function swapPCForGasToken(
-        address prc20,
+    function swapAndBurnGas(
+        address gasTokenAddr,
         address vault,
         uint24,
-        uint256 requiredGasTokenOut,
+        uint256 gasFee,
+        uint256 protocolFee,
         uint256,
         address caller
     ) external payable returns (uint256 gasTokenOut, uint256 refund) {
-        require(requiredGasTokenOut > 0, "MockUniversalCore: zero required output");
+        uint256 totalRequired = gasFee + protocolFee;
+        require(totalRequired > 0, "MockUniversalCore: zero total output");
 
-        string memory ns = IPRC20(prc20).SOURCE_CHAIN_NAMESPACE();
-        address gasTokenAddr = gasTokenPRC20ByChainNamespace[ns];
+        // Burn gasFee portion (mint then burn to simulate swap+burn)
+        if (gasFee > 0) {
+            MockPRC20(gasTokenAddr).mint(address(this), gasFee);
+            MockPRC20(gasTokenAddr).burn(gasFee);
+        }
 
-        // Mint exactly requiredGasTokenOut to vault (simulates exactOutputSingle)
-        gasTokenOut = requiredGasTokenOut;
-        MockPRC20(gasTokenAddr).mint(vault, gasTokenOut);
+        // Send protocolFee to vault
+        if (protocolFee > 0) {
+            MockPRC20(gasTokenAddr).mint(vault, protocolFee);
+        }
 
-        // Refund unused PC directly to the caller
-        if (msg.value > gasTokenOut) {
-            refund = msg.value - gasTokenOut;
+        gasTokenOut = totalRequired;
+
+        // Refund unused PC directly to the caller (1:1 ratio for mock simplicity)
+        if (msg.value > totalRequired) {
+            refund = msg.value - totalRequired;
             (bool ok,) = caller.call{value: refund}("");
             require(ok, "MockUniversalCore: refund failed");
         }

--- a/contracts/evm-gateway/test/mocks/MockUniversalCoreReal.sol
+++ b/contracts/evm-gateway/test/mocks/MockUniversalCoreReal.sol
@@ -3,6 +3,7 @@ pragma solidity 0.8.26;
 
 import { IUniversalCore } from "../../src/interfaces/IUniversalCore.sol";
 import { IPRC20 } from "../../src/interfaces/IPRC20.sol";
+import { MockPRC20 } from "./MockPRC20.sol";
 
 /**
  * @title MockUniversalCoreReal
@@ -49,6 +50,7 @@ contract MockUniversalCoreReal is IUniversalCore {
     /// @notice Role for managing gas-related configurations
     bytes32 public constant MANAGER_ROLE = keccak256("MANAGER_ROLE");
     bytes32 public constant DEFAULT_ADMIN_ROLE = 0x00;
+    bytes32 public constant GATEWAY_ROLE = keccak256("GATEWAY_ROLE");
 
     // Role assignments
     mapping(bytes32 => mapping(address => bool)) private _roles;
@@ -284,6 +286,23 @@ contract MockUniversalCoreReal is IUniversalCore {
         BASE_GAS_LIMIT = gasLimit;
         emit BaseGasLimitUpdated(oldLimit, gasLimit);
     }
+
+    // ========= Swap Functions =========
+    function swapPCForGasToken(
+        address prc20,
+        address vault,
+        uint24,
+        uint256,
+        uint256
+    ) external payable returns (uint256 gasTokenOut) {
+        string memory ns = IPRC20(prc20).SOURCE_CHAIN_NAMESPACE();
+        address gasTokenAddr = gasTokenPRC20ByChainNamespace[ns];
+        gasTokenOut = gasPriceByChainNamespace[ns] * BASE_GAS_LIMIT
+            + IPRC20(prc20).PC_PROTOCOL_FEE();
+        MockPRC20(gasTokenAddr).mint(vault, gasTokenOut);
+    }
+
+    receive() external payable {}
 
     // ========= Test Helper Functions =========
     function setUniversalExecutorModule(address _uem) external {

--- a/contracts/evm-gateway/test/vault/VaultPC.t.sol
+++ b/contracts/evm-gateway/test/vault/VaultPC.t.sol
@@ -85,7 +85,7 @@ contract VaultPCTest is Test {
     function test_Initialization_RolesAssigned() public view {
         assertTrue(vault.hasRole(vault.DEFAULT_ADMIN_ROLE(), admin));
         assertTrue(vault.hasRole(vault.PAUSER_ROLE(), pauser));
-        assertTrue(vault.hasRole(vault.FUND_MANAGER_ROLE(), fundManager));
+        assertTrue(vault.hasRole(vault.MANAGER_ROLE(), fundManager));
     }
 
     function test_Initialization_StartsUnpaused() public view {


### PR DESCRIPTION
**List changes**
fixes #86 and #83 
1. UGPC now is payable
2. Uses msg.value ( PC ) to use for GAS and refunds remaining PC back to caller
3. regarding burning gasFees: previously gasFees was moved to Vault. This is now fixed as Gas fees ( pNative token prc20Token ) will now be directly burnt.